### PR TITLE
feat(tofu): set up OpenTofu PoC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Ignore files related to Terraform.
+**/.terraform/
+**/.terraform.lock.hcl
+deploy/tofu/out/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+define HELP_HEADER
+Usage:	make <target>
+
+Targets:
+endef
+
+export HELP_HEADER
+
+.PHONY: help
+help: ## List all targets.
+	@echo "$$HELP_HEADER"
+	@grep -E '^[a-zA-Z0-9%_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-10s\033[0m %s\n", $$1, $$2}'
+
+.PHONY: plan
+plan: ## Plan the infrastructure changes.
+	terraform -chdir=deploy/tofu plan
+
+.PHONY: apply
+apply: ## Apply the infrastructure changes.
+	terraform -chdir=deploy/tofu apply -auto-approve

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Cloud
+# Homelab
 
 This repository contains the configuration of all my infrastructure.
 
 ## Provisioning
 
-To provision the Kubernetes clusters and DNS records, [OpenTofu][opentofu] is used.
+To provision the Kubernetes clusters, [OpenTofu][opentofu] is used.
 
 [opentofu]: https://opentofu.org/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
-# Fleet
+# Cloud
 
 This repository contains the configuration of all my infrastructure.
+
+## Provisioning
+
+To provision the Kubernetes clusters and DNS records, [OpenTofu][opentofu] is used.
+
+[opentofu]: https://opentofu.org/

--- a/configs/regions.yaml
+++ b/configs/regions.yaml
@@ -1,0 +1,10 @@
+apiVersion: cloud.nicklasfrahm.dev/v1alpha1
+kind: Region
+metadata:
+  name: hel01
+spec:
+  provider: Baremetal
+  baremetal:
+    controlplanes:
+      - name: antelope
+        ip:

--- a/configs/regions/hel01.yaml
+++ b/configs/regions/hel01.yaml
@@ -1,0 +1,6 @@
+apiVersion: cloud.nicklasfrahm.dev/v1alpha1
+kind: Region
+metadata:
+  name: hel01
+spec:
+  provider: Baremetal

--- a/deploy/tofu/main.tf
+++ b/deploy/tofu/main.tf
@@ -1,0 +1,12 @@
+locals {
+  region_files = fileset("${path.cwd}/configs/regions", "*.yaml")
+  region_configs = { for f in local.region_files : replace(f, ".yaml", "") => yamldecode(file("${path.cwd}/configs/regions/${f}")) }
+}
+
+module "region" {
+  source = "./modules/region"
+
+  for_each = local.region_configs
+
+  config = each.value
+}

--- a/deploy/tofu/modules/region/main.tf
+++ b/deploy/tofu/modules/region/main.tf
@@ -1,0 +1,4 @@
+resource "local_file" "config" {
+  content  = yamlencode(var.config)
+  filename = "${path.cwd}/deploy/tofu/out/${var.config.metadata.name}.out"
+}

--- a/deploy/tofu/modules/region/variables.tf
+++ b/deploy/tofu/modules/region/variables.tf
@@ -1,0 +1,11 @@
+variable "config" {
+  type = object({
+    metadata = object({
+      name = string
+    })
+    spec = object({
+      provider = string
+    })
+  })
+  description = "The configuration of the region."
+}

--- a/deploy/tofu/provider.tf
+++ b/deploy/tofu/provider.tf
@@ -1,0 +1,6 @@
+terraform {
+  backend "gcs" {
+    bucket = "nicklasfrahm"
+    prefix  = "tofu/state/homelab"
+  }
+}

--- a/deploy/tofu/variables.tf
+++ b/deploy/tofu/variables.tf
@@ -1,0 +1,4 @@
+# variable "GOOGLE_PROJECT_ID" {
+#   type = string
+#   description = "The Google Cloud Project ID."
+# }


### PR DESCRIPTION
This sets up a PoC that configures a basic [OpenTofu](https://opentofu.org) project structure. Input files are provided via YAML manifests.