### PR TITLE
fix(ci): allow OIDC federation

### DIFF
--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  id-token: write
+
 jobs:
   validate:
     name: Validate


### PR DESCRIPTION
Allow OIDC federation so that GitHub Actions can publish to GitHub pages.