### PR TITLE
fix(ci): avoid missing write permissions to GitHub pages

### DIFF
--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -8,9 +8,6 @@ on:
     branches:
       - main
 
-permissions:
-  id-token: write
-
 jobs:
   validate:
     name: Validate
@@ -36,6 +33,9 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
+    permissions:
+      id-token: write
+      pages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This ensures that the token has permission to write to GitHub pages.