### PR TITLE
feat(cli): flatten API and add list endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This repository contains the configuration of all my infrastructure. Some components use the [Operator SDK][operator-sdk] to manage resources.
 
+## Documentation
+
+- [API](./docs/api.md)
+
 ## Provisioning
 
 To provision the Kubernetes clusters, [OpenTofu][opentofu] is used.

--- a/api/v1beta1/machine_types.go
+++ b/api/v1beta1/machine_types.go
@@ -98,22 +98,31 @@ func (m MAC) MarshalJSON() ([]byte, error) {
 // Interface describes a network interface of a Machine.
 type Interface struct {
 	// MAC is the MAC address of the interface.
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Format=mac
 	MAC MAC `json:"mac"`
 }
 
 // MachineSpecHardware defines the hardware configuration of a Machine.
 type MachineSpecHardware struct {
 	// Vendor is the manufacturer of the machine.
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:Required
 	Vendor string `json:"vendor"`
 	// Model is the model of the machine.
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:Required
 	Model string `json:"model"`
 }
 
 // MachineSpec defines the desired state of Machine.
 type MachineSpec struct {
 	// Hardware is the hardware configuration of the machine.
+	// +kubebuilder:validation:Required
 	Hardware MachineSpecHardware `json:"hardware"`
 	// Interfaces describes the network interfaces of the machine.
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MinItems=1
 	Interfaces []Interface `json:"interfaces"`
 }
 

--- a/config/crd/bases/cloud.nicklasfrahm.dev_machines.yaml
+++ b/config/crd/bases/cloud.nicklasfrahm.dev_machines.yaml
@@ -44,9 +44,11 @@ spec:
                 properties:
                   model:
                     description: Model is the model of the machine.
+                    minLength: 1
                     type: string
                   vendor:
                     description: Vendor is the manufacturer of the machine.
+                    minLength: 1
                     type: string
                 required:
                 - model
@@ -58,12 +60,15 @@ spec:
                   description: Interface describes a network interface of a Machine.
                   properties:
                     mac:
+                      allOf:
+                      - format: byte
+                      - format: mac
                       description: MAC is the MAC address of the interface.
-                      format: byte
                       type: string
                   required:
                   - mac
                   type: object
+                minItems: 1
                 type: array
             required:
             - hardware

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,68 @@
+# API
+
+This document describes the API of my configuration management tool.
+
+## Endpoints
+
+The API is inspired by Kubernetes and is available at [`https://cloud.nicklasfrahm.dev`](https://cloud.nicklasfrahm.dev/).
+
+### `GET /v1beta1/machines`
+
+Returns a list of all machines.
+
+```json
+{
+  "kind": "MachineList",
+  "apiVersion": "cloud.nicklasfrahm.dev/v1beta1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "Machine",
+      "apiVersion": "cloud.nicklasfrahm.dev/v1beta1",
+      "metadata": {
+        "name": "ant",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "hardware": {
+          "vendor": "FriendlyElec",
+          "model": "NanoPiR5S"
+        },
+        "interfaces": [
+          {
+            "mac": "32:de:fa:97:71:4f"
+          }
+        ]
+      },
+      "status": {}
+    }
+  ]
+}
+```
+
+### `GET /v1beta1/machines/{name}`
+
+Returns the configuration of a single machine.
+
+```json
+{
+  "kind": "Machine",
+  "apiVersion": "cloud.nicklasfrahm.dev/v1beta1",
+  "metadata": {
+    "name": "ant",
+    "creationTimestamp": null
+  },
+  "spec": {
+    "hardware": {
+      "vendor": "FriendlyElec",
+      "model": "NanoPiR5S"
+    },
+    "interfaces": [
+      {
+        "mac": "32:de:fa:97:71:4f"
+      }
+    ]
+  },
+  "status": {}
+}
+```

--- a/pkg/kubeenc/json.go
+++ b/pkg/kubeenc/json.go
@@ -1,4 +1,4 @@
-package io
+package kubeenc
 
 import (
 	"fmt"
@@ -23,9 +23,14 @@ func NewJSONEncoder(writer io.Writer) *JSONEncoder {
 
 // Encode encodes JSON for a Kubernetes API object.
 func (e *JSONEncoder) Encode(obj runtime.Object) ([]byte, error) {
+	return e.EncodeWithScheme(obj, scheme.Scheme)
+}
+
+// EncodeWithScheme encodes JSON for a Kubernetes API object with a custom scheme.
+func (e *JSONEncoder) EncodeWithScheme(obj runtime.Object, customScheme *runtime.Scheme) ([]byte, error) {
 	printer, err := genericclioptions.
 		NewPrintFlags("render").
-		WithTypeSetter(scheme.Scheme).
+		WithTypeSetter(customScheme).
 		WithDefaultOutput("json").
 		ToPrinter()
 	if err != nil {
@@ -33,7 +38,7 @@ func (e *JSONEncoder) Encode(obj runtime.Object) ([]byte, error) {
 	}
 
 	if err := printer.PrintObj(obj, e.writer); err != nil {
-		return nil, fmt.Errorf("failed to print secret: %w", err)
+		return nil, fmt.Errorf("failed to print object: %w", err)
 	}
 
 	return nil, nil


### PR DESCRIPTION
This removes the API groups and only keeps the version directory. Additionally, a list of all resources is available now.