### PR TITLE
fix(docs): publish redirect front page

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -129,6 +129,9 @@ jobs:
       - name: Build manifests
         run: go run cmd/cloudctl/*.go config build ./configs ./build
 
+      - name: Publish index.html
+        run: cp public/index.html build/index.html
+
       - name: Upload to GitHub Pages
         uses: actions/upload-pages-artifact@v3
         with:

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
+    <title>Cloud API</title>
+    <style>
+      body {
+        background-color: #25282c;
+      }
+    </style>
+    <script>
+      window.location.href =
+        "https://doc.crds.dev/github.com/nicklasfrahm/cloud";
+    </script>
+  </head>
+  <body>
+    <h1 style="color: white; text-align: center; margin-top: 50vh">
+      Redirecting to documentation...
+    </h1>
+  </body>
+</html>


### PR DESCRIPTION
Create a front page that redirects to [`doc.crds.dev`](https://doc.crds.dev).