### PR TITLE
fix(ci): index CRDs on doc.crds.dev

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -224,3 +224,6 @@ jobs:
             ]
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Index CRDs
+        run: curl -X GET "https://doc.crds.dev/github.com/nicklasfrahm/cloud@${RELEASE_GIT_TAG}"


### PR DESCRIPTION
This automatically indexes the new version by sending a `GET` request to `doc.crds.dev`.