### PR TITLE
chore(ci): set up dependabot for gomodules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,13 @@ updates:
       terraform:
         patterns:
           - "*"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "fix(deps)"
+    groups:
+      gomodules:
+        patterns:
+          - "*"


### PR DESCRIPTION
This sets up dependabot to update the gomodules dependencies once a week.