### PR TITLE
fix(ci): fix helm registry login

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -407,6 +407,16 @@ jobs:
         run: |
           set -eou pipefail
 
+          cd pr
+
+          mapfile -t charts < <(find charts -mindepth 1 -maxdepth 1 -type d)
+
+          cd ..
+
+          for chart in "${charts[@]}"; do
+            [[ ! -f "pr/charts/$chart/Chart.lock" ]] && helm dependency build pr/charts/$chart
+          done
+
           if output=$(helm lint pr/charts/* --strict); then
             echo 'result=0' >>"$GITHUB_OUTPUT"
           else

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -414,7 +414,7 @@ jobs:
           cd ..
 
           for chart in "${charts[@]}"; do
-            [[ ! -f "pr/charts/$chart/Chart.lock" ]] && helm dependency build pr/charts/$chart
+            [[ ! -f "pr/$chart/Chart.lock" ]] && helm dependency build pr/$chart
           done
 
           if output=$(helm lint pr/charts/* --strict); then

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -479,7 +479,7 @@ jobs:
         run: |
           set -eou pipefail
 
-          echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login --username ${{ github.actor }} --password-stdin
+          echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io --username ${{ github.actor }} --password-stdin
 
           mapfile -t changed_charts < <(git diff --name-only HEAD~1 | grep -oP 'charts/\K[^/]+' | sort -u)
 


### PR DESCRIPTION
This avoids a missing argument in the `helm registry login`  command [as seen here](https://github.com/nicklasfrahm/cloud/actions/runs/14011434512/job/39231717223):

```log
Error: "helm registry login" requires at least 1 argument

Usage:  helm registry login [host] [flags]
```