### PR TITLE
fix(dependabot): include all charts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,7 +32,8 @@ updates:
         patterns:
           - "*"
   - package-ecosystem: "helm"
-    directory: "charts/"
+    directories:
+      - "/charts/*"
     schedule:
       interval: "weekly"
     commit-message:


### PR DESCRIPTION
Ensures that dependabot finds all helm charts.