### PR TITLE
fix(ci): attach charts to user instead of repo

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -495,5 +495,5 @@ jobs:
 
           for chart in "${changed_charts[@]}"; do
             helm package "charts/$chart"
-            helm push $chart-*.tgz oci://ghcr.io/nicklasfrahm/cloud/charts
+            helm push $chart-*.tgz oci://ghcr.io/nicklasfrahm/charts
           done


### PR DESCRIPTION
This changes the chart namespace to avoid the repository name in it.