### PR TITLE
fix(ci): avoid missing Chart.lock file

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -506,6 +506,7 @@ jobs:
           mapfile -t changed_charts < <(git diff --name-only HEAD~1 | grep -oP 'charts/\K[^/]+' | sort -u)
 
           for chart in "${changed_charts[@]}"; do
+            [[ ! -f "charts/$chart/Chart.lock" ]] && helm dependency build "charts/$chart"
             helm package "charts/$chart"
             helm push $chart-*.tgz oci://ghcr.io/nicklasfrahm/charts
           done

--- a/charts/cilium/Chart.yaml
+++ b/charts/cilium/Chart.yaml
@@ -3,7 +3,7 @@ type: application
 name: cilium
 description: Deploy the Cilium CNI.
 icon: https://artifacthub.io/image/2ae85972-bf12-41a5-afb2-9b1147b2aa56
-version: 0.1.0
+version: 0.1.1
 appVersion: "1.17.1"
 dependencies:
   - repository: https://helm.cilium.io/


### PR DESCRIPTION
This ensures that all dependencies are present before publishing the helm chart.