### PR TITLE
fix(cilium): enable ingress support

### DIFF
--- a/charts/cilium/Chart.yaml
+++ b/charts/cilium/Chart.yaml
@@ -3,7 +3,7 @@ type: application
 name: cilium
 description: Deploy the Cilium CNI.
 icon: https://artifacthub.io/image/2ae85972-bf12-41a5-afb2-9b1147b2aa56
-version: 0.1.1
+version: 0.1.2
 appVersion: "1.17.1"
 dependencies:
   - repository: https://helm.cilium.io/

--- a/charts/cilium/values.yaml
+++ b/charts/cilium/values.yaml
@@ -43,3 +43,9 @@ cilium:
   # Docs: https://docs.cilium.io/en/latest/network/node-ipam/
   nodeIPAM:
     enabled: true
+
+  # Enable support for ingress.
+  ingressController:
+    enabled: true
+    loadbalancerMode: shared
+    default: true


### PR DESCRIPTION
This enables `cilium` to provide the ingress controller.