### PR TITLE
fix(cilium): default to node IPAM for LBs

### DIFF
--- a/charts/cilium/Chart.yaml
+++ b/charts/cilium/Chart.yaml
@@ -3,7 +3,7 @@ type: application
 name: cilium
 description: Deploy the Cilium CNI.
 icon: https://artifacthub.io/image/2ae85972-bf12-41a5-afb2-9b1147b2aa56
-version: 0.1.2
+version: 0.1.3
 appVersion: "1.17.1"
 dependencies:
   - repository: https://helm.cilium.io/

--- a/charts/cilium/values.yaml
+++ b/charts/cilium/values.yaml
@@ -43,6 +43,7 @@ cilium:
   # Docs: https://docs.cilium.io/en/latest/network/node-ipam/
   nodeIPAM:
     enabled: true
+  defaultLBServiceIPAM: nodeipam
 
   # Enable support for ingress.
   ingressController:


### PR DESCRIPTION
This configures `cilium` to default to the node IPAM when provisioning LBs.