### PR TITLE
fix(talos): allow node IPAM on Talos nodes

### DIFF
--- a/modules/talos_cluster/main.tf
+++ b/modules/talos_cluster/main.tf
@@ -77,11 +77,6 @@ data "talos_machine_configuration" "worker" {
         network = {
           hostname = each.key
         }
-        nodeLabels = {
-          "node.kubernetes.io/exclude-from-external-load-balancers" = {
-            "$patch" = "delete"
-          }
-        }
       }
     })
   ])

--- a/modules/talos_cluster/main.tf
+++ b/modules/talos_cluster/main.tf
@@ -77,6 +77,11 @@ data "talos_machine_configuration" "worker" {
         network = {
           hostname = each.key
         }
+        nodeLabels = {
+          "node.kubernetes.io/exclude-from-external-load-balancers" = {
+            "$patch" = "delete"
+          }
+        }
       }
     })
   ])

--- a/modules/talos_cluster/patches/base.yaml
+++ b/modules/talos_cluster/patches/base.yaml
@@ -100,3 +100,9 @@ cluster:
                       helm upgrade --install cilium oci://ghcr.io/nicklasfrahm/charts/cilium \
                         --namespace kube-system \
                         --set cilium.operator.replicas=${cilium_operator_replicas}
+
+machine:
+  nodeLabels:
+    # Allow cilium to use the node's IP address for external load balancers.
+    node.kubernetes.io/exclude-from-external-load-balancers:
+      "$patch": "delete"


### PR DESCRIPTION
Allow `cilium` to use the talos node IPs for load balancers.