### PR TITLE
fix(talos): add talosconfig output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ charts/*/Chart.lock
 # Kubernetes credentials.
 kubeconfig.yaml
 kubeconfig.yml
+
+# Talos credentials.
+talosconfig

--- a/deploy/opentofu/main.tf
+++ b/deploy/opentofu/main.tf
@@ -39,6 +39,16 @@ output "kubeconfigs" {
   }
 }
 
+output "talosconfigs" {
+  description = "A map of Talos configs for each cluster."
+  depends_on  = [module.talos_cluster]
+  sensitive   = true
+  value = {
+    for cluster in local.taloscluster_configs :
+    cluster.metadata.name => module.talos_cluster[cluster.metadata.name].talosconfig_admin != null ? module.talos_cluster[cluster.metadata.name].talosconfig_admin : ""
+  }
+}
+
 provider "helm" {
   kubernetes {
     host                   = module.talos_cluster["hel01"].kubeconfig_credentials.host

--- a/modules/talos_cluster/main.tf
+++ b/modules/talos_cluster/main.tf
@@ -44,6 +44,7 @@ data "talos_client_configuration" "this" {
     keys(local.controlplane_machines),
     keys(local.worker_machines)
   )
+  endpoints = keys(local.controlplane_machines)
 }
 
 data "talos_machine_configuration" "controlplane" {

--- a/modules/talos_cluster/outputs.tf
+++ b/modules/talos_cluster/outputs.tf
@@ -1,3 +1,9 @@
+output "talosconfig_admin" {
+  description = "The Talos config for the cluster."
+  depends_on  = [data.talos_client_configuration.this]
+  value       = data.talos_client_configuration.this.talos_config
+}
+
 output "kubeconfig_user" {
   description = "The kubeconfig file for the cluster."
   depends_on  = [talos_cluster_kubeconfig.this]


### PR DESCRIPTION
This adds an output for the `talosconfig` to allow break-glass access to Talos cluster.