### PR TITLE
fix(cilium): enable TLSRoute by default

### DIFF
--- a/charts/cilium/Chart.yaml
+++ b/charts/cilium/Chart.yaml
@@ -3,7 +3,7 @@ type: application
 name: cilium
 description: Deploy the Cilium CNI.
 icon: https://artifacthub.io/image/2ae85972-bf12-41a5-afb2-9b1147b2aa56
-version: 0.2.5
+version: 0.2.6
 appVersion: "1.17.5"
 dependencies:
   - repository: https://helm.cilium.io/

--- a/charts/cilium/values.yaml
+++ b/charts/cilium/values.yaml
@@ -67,7 +67,7 @@ hooks:
     version: "1.2.0"
     # Whether to install experimental CRDs. May be either "standard" or "experimental".
     # Docs: https://gateway-api.sigs.k8s.io/concepts/versioning/
-    channel: "standard"
+    channel: "experimental"
     # Which CRDs to install.
     # Reference: https://github.com/kubernetes-sigs/gateway-api/tree/v1.2.0/config/crd/standard
     resources:
@@ -76,5 +76,4 @@ hooks:
       - gateway.networking.k8s.io_httproutes
       - gateway.networking.k8s.io_referencegrants
       - gateway.networking.k8s.io_grpcroutes
-      # Uncomment the following line to enable experimental CRDs.
-      # - gateway.networking.k8s.io_tlsroutes
+      - gateway.networking.k8s.io_tlsroutes


### PR DESCRIPTION
This should work without the `TLSRoute` installed, but the operator is not happy.
```
$ k logs -f -l name=cilium-operator | grep gateway
time=2025-06-29T19:14:06Z level=info msg="Queueing gateway" module=operator.operator-controlplane.leader-lifecycle.gateway-api controller=gateway resource=cilium k8sNamespace=kube-system resource=shared-http
time=2025-06-29T19:14:06Z level=info msg="Reconciling Gateway" module=operator.operator-controlplane.leader-lifecycle.gateway-api controller=gateway resource=kube-system/shared-http
time=2025-06-29T19:14:06Z level=error msg="Unable to list TLSRoutes" module=operator.operator-controlplane.leader-lifecycle.gateway-api controller=gateway resource=kube-system/shared-http error="no kind is registered for the type v1alpha2.TLSRouteList in scheme \"k8s.io/client-go/kubernetes/scheme/register.go:83\""
time=2025-06-29T19:14:06Z level=error msg="Reconciler error" module=operator.operator-controlplane.leader-lifecycle.controller-runtime controller=gateway controllerGroup=gateway.networking.k8s.io controllerKind=Gateway Gateway.name=shared-http Gateway.namespace=kube-system namespace=kube-system name=shared-http reconcileID=05f5729c-579a-4532-87e4-d1f6c3df8470 error="no kind is registered for the type v1alpha2.TLSRouteList in scheme \"k8s.io/client-go/kubernetes/scheme/register.go:83\""
```