### PR TITLE
feat(helm): add envoy-gateway umbrella chart

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,15 +7,19 @@
 All commits must follow the **Conventional Commits** specification.
 
 ### Format
+
 `<type>(<scope>): <description>`
 
 ### Rules
+
 - **Types**:
   - `feat`: A new feature.
   - `fix`: A bug fix.
 - **Scope**: The scope (e.g., `llm`, `ci`, `argocd`) is **always required**.
 - **Description**: The message must be written in the **imperative mood** (e.g., "add feature" instead of "added feature" or "adds feature").
+- **PR Description**: There should never be a test plan or attribution to Crush in the PR description.
 
 ### Examples
+
 - `feat(llm): add gemma4 deployment config`
 - `fix(argocd): resolve authentication issue`

--- a/charts/envoy-gateway/Chart.yaml
+++ b/charts/envoy-gateway/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: envoy-gateway
+description: Umbrella chart for Envoy Gateway and its CRDs
+version: 1.0.0
+dependencies:
+  - name: envoy-gateway
+    version: 0.8.0
+    repository: https://gateway.envoyproxy.io/
+  - name: envoy-gateway-crd
+    version: 0.8.0
+    repository: https://gateway.envoyproxy.io/

--- a/charts/envoy-gateway/Chart.yaml
+++ b/charts/envoy-gateway/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: envoy-gateway
 description: Umbrella chart for Envoy Gateway and its CRDs
-version: 1.0.0
+version: 0.1.0
 dependencies:
   - name: envoy-gateway
     version: 0.8.0

--- a/charts/envoy-gateway/templates/.gitkeep
+++ b/charts/envoy-gateway/templates/.gitkeep
@@ -1,0 +1,1 @@
+.gitkeep

--- a/charts/envoy-gateway/values.yaml
+++ b/charts/envoy-gateway/values.yaml
@@ -1,0 +1,2 @@
+# Envoy Gateway Umbrella Chart Values
+# This file can be used to override values for the subcharts.

--- a/docs/vllm-setup-guide.md
+++ b/docs/vllm-setup-guide.md
@@ -35,7 +35,34 @@ To configure Crush to use your private vLLM instance, you need to edit your `cru
 }
 ```
 
-## Key Parameters
+### Example opencode Configuration
+
+If you are using opencode, your configuration in `~/.config/opencode/opencode.json` might look like this:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "vllm": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "vLLM",
+      "options": {
+        "baseURL": "https://llm.cph02.nicklasfrahm.dev/v1"
+      },
+      "models": {
+        "cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit": {
+          "name": "Gemma 4 MoE",
+          "limit": {
+            "context": 131072,
+            "output": 16384
+          }
+        }
+      }
+    }
+  }
+}
+```
+
 
 - `type`: Set this to `"openai-compat"` as vLLM implements the OpenAI API specification.
 - `base_url`: The full URL to your vLLM `/v1` endpoint.


### PR DESCRIPTION
## Summary

- Add the Envoy Gateway umbrella Helm chart.
- Includes dependencies for `envoy-gateway` and `envoy-gateway-crd`.