### PR TITLE
fix(config): enable oauth2-proxy for rook-ceph-cluster on prd-cph02

### DIFF
--- a/deploy/services/rook-ceph-cluster/20-cluster-prd-cph02.yml
+++ b/deploy/services/rook-ceph-cluster/20-cluster-prd-cph02.yml
@@ -191,6 +191,7 @@ rook-ceph-cluster:
             name: shared-http
 
 oauth2-proxy:
+  enabled: true
   config:
     upstreams:
       - http://rook-ceph-mgr-dashboard:7000


### PR DESCRIPTION
## Summary

- Set `oauth2-proxy.enabled: true` in the prd-cph02 cluster values for `rook-ceph-cluster`

The key was missing after the proxy was folded into the umbrella chart, so the proxy, HTTPRoute, and SSO setup job would not have been deployed.