### PR TITLE
fix(charts): expand ArgoCD RBAC platform role with all explicit permissions

### DIFF
--- a/charts/argocd/Chart.yaml
+++ b/charts/argocd/Chart.yaml
@@ -3,13 +3,13 @@ type: application
 name: argocd
 description: Deploy ArgoCD for continuous delivery and GitOps workflows.
 icon: https://artifacthub.io/image/e16221f4-a3b1-49f6-9b65-cb4dbf30ed83
-version: 1.0.3
-appVersion: "9.1.0"
+version: 1.0.4
+appVersion: "9.5.14"
 dependencies:
   - repository: oci://ghcr.io/argoproj/argo-helm
     name: argo-cd
     alias: argocd
-    version: 9.1.0
+    version: 9.5.14
     condition: argocd.enabled
     tags:
       - gitops

--- a/charts/argocd/Chart.yaml
+++ b/charts/argocd/Chart.yaml
@@ -3,7 +3,7 @@ type: application
 name: argocd
 description: Deploy ArgoCD for continuous delivery and GitOps workflows.
 icon: https://artifacthub.io/image/e16221f4-a3b1-49f6-9b65-cb4dbf30ed83
-version: 1.0.2
+version: 1.0.3
 appVersion: "9.1.0"
 dependencies:
   - repository: oci://ghcr.io/argoproj/argo-helm

--- a/charts/argocd/values.yaml
+++ b/charts/argocd/values.yaml
@@ -21,40 +21,17 @@ argocd:
       scopes: "[groups, email]"
       policy.default: ""
       policy.custom.csv: |
-        p, role:platform, applications, get, */*, allow
-        p, role:platform, applications, create, */*, allow
-        p, role:platform, applications, update, */*, allow
-        p, role:platform, applications, delete, */*, allow
-        p, role:platform, applications, sync, */*, allow
-        p, role:platform, applications, action, */*, allow
-        p, role:platform, applications, override, */*, allow
-        p, role:platform, applicationsets, get, */*, allow
-        p, role:platform, applicationsets, create, */*, allow
-        p, role:platform, applicationsets, update, */*, allow
-        p, role:platform, applicationsets, delete, */*, allow
-        p, role:platform, clusters, get, *, allow
-        p, role:platform, clusters, create, *, allow
-        p, role:platform, clusters, update, *, allow
-        p, role:platform, clusters, delete, *, allow
-        p, role:platform, projects, get, *, allow
-        p, role:platform, projects, create, *, allow
-        p, role:platform, projects, update, *, allow
-        p, role:platform, projects, delete, *, allow
-        p, role:platform, repositories, get, *, allow
-        p, role:platform, repositories, create, *, allow
-        p, role:platform, repositories, update, *, allow
-        p, role:platform, repositories, delete, *, allow
-        p, role:platform, accounts, get, *, allow
-        p, role:platform, accounts, update, *, allow
-        p, role:platform, certificates, get, *, allow
-        p, role:platform, certificates, create, *, allow
-        p, role:platform, certificates, delete, *, allow
-        p, role:platform, gpgkeys, get, *, allow
-        p, role:platform, gpgkeys, create, *, allow
-        p, role:platform, gpgkeys, delete, *, allow
-        p, role:platform, logs, get, */*, allow
-        p, role:platform, exec, create, */*, allow
-        p, role:platform, extensions, invoke, */*, allow
+        p, role:platform, applications, *, */*, allow
+        p, role:platform, applicationsets, *, */*, allow
+        p, role:platform, clusters, *, *, allow
+        p, role:platform, projects, *, *, allow
+        p, role:platform, repositories, *, *, allow
+        p, role:platform, accounts, *, *, allow
+        p, role:platform, certificates, *, *, allow
+        p, role:platform, gpgkeys, *, *, allow
+        p, role:platform, logs, *, */*, allow
+        p, role:platform, exec, *, */*, allow
+        p, role:platform, extensions, *, */*, allow
 
         g, nicklasfrahm-dev:platform, role:platform
     params:

--- a/charts/argocd/values.yaml
+++ b/charts/argocd/values.yaml
@@ -21,10 +21,40 @@ argocd:
       scopes: "[groups, email]"
       policy.default: ""
       policy.custom.csv: |
-        p, role:platform, applicationsets, *, */*, allow
-        p, role:platform, applications, *, */*, allow
+        p, role:platform, applications, get, */*, allow
+        p, role:platform, applications, create, */*, allow
+        p, role:platform, applications, update, */*, allow
+        p, role:platform, applications, delete, */*, allow
+        p, role:platform, applications, sync, */*, allow
+        p, role:platform, applications, action, */*, allow
+        p, role:platform, applications, override, */*, allow
+        p, role:platform, applicationsets, get, */*, allow
+        p, role:platform, applicationsets, create, */*, allow
+        p, role:platform, applicationsets, update, */*, allow
+        p, role:platform, applicationsets, delete, */*, allow
         p, role:platform, clusters, get, *, allow
+        p, role:platform, clusters, create, *, allow
+        p, role:platform, clusters, update, *, allow
+        p, role:platform, clusters, delete, *, allow
+        p, role:platform, projects, get, *, allow
+        p, role:platform, projects, create, *, allow
+        p, role:platform, projects, update, *, allow
+        p, role:platform, projects, delete, *, allow
         p, role:platform, repositories, get, *, allow
+        p, role:platform, repositories, create, *, allow
+        p, role:platform, repositories, update, *, allow
+        p, role:platform, repositories, delete, *, allow
+        p, role:platform, accounts, get, *, allow
+        p, role:platform, accounts, update, *, allow
+        p, role:platform, certificates, get, *, allow
+        p, role:platform, certificates, create, *, allow
+        p, role:platform, certificates, delete, *, allow
+        p, role:platform, gpgkeys, get, *, allow
+        p, role:platform, gpgkeys, create, *, allow
+        p, role:platform, gpgkeys, delete, *, allow
+        p, role:platform, logs, get, */*, allow
+        p, role:platform, exec, create, */*, allow
+        p, role:platform, extensions, invoke, */*, allow
 
         g, nicklasfrahm-dev:platform, role:platform
     params:

--- a/charts/rook-ceph-cluster/Chart.yaml
+++ b/charts/rook-ceph-cluster/Chart.yaml
@@ -3,7 +3,7 @@ name: rook-ceph-cluster
 description: A Helm chart to deploy a Rook Ceph Cluster
 icon: https://upload.wikimedia.org/wikipedia/commons/0/07/Ceph_Logo_Stacked_RGB.png
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: "1.18.7"
 dependencies:
   - repository: https://charts.rook.io/release

--- a/charts/rook-ceph-cluster/Chart.yaml
+++ b/charts/rook-ceph-cluster/Chart.yaml
@@ -3,12 +3,12 @@ name: rook-ceph-cluster
 description: A Helm chart to deploy a Rook Ceph Cluster
 icon: https://upload.wikimedia.org/wikipedia/commons/0/07/Ceph_Logo_Stacked_RGB.png
 type: application
-version: 0.3.1
-appVersion: "1.18.7"
+version: 0.3.2
+appVersion: "1.19.5"
 dependencies:
   - repository: https://charts.rook.io/release
     name: rook-ceph-cluster
-    version: 1.18.7
+    version: 1.19.5
     condition: rook-ceph-cluster.enabled
     tags:
       - storage

--- a/charts/rook-ceph-cluster/values.yaml
+++ b/charts/rook-ceph-cluster/values.yaml
@@ -55,7 +55,7 @@ oauth2-proxy:
       - "*"
   extraArgs:
     - --provider=oidc
-    - --pkce-code-challenge-method=S256
+    - --code-challenge-method=S256
     - --oidc-issuer-url=https://auth.nicklasfrahm.dev
     - --client-secret=
     - --oidc-groups-claim=groups

--- a/deploy/services/rook-ceph-cluster/20-cluster-prd-cph02.yml
+++ b/deploy/services/rook-ceph-cluster/20-cluster-prd-cph02.yml
@@ -197,7 +197,7 @@ oauth2-proxy:
       - http://rook-ceph-mgr-dashboard:7000
   extraArgs:
     - --provider=oidc
-    - --pkce-code-challenge-method=S256
+    - --code-challenge-method=S256
     - --oidc-issuer-url=https://auth.nicklasfrahm.dev
     - --client-secret=
     - --oidc-groups-claim=groups


### PR DESCRIPTION
## Summary

- Lists all 11 ArgoCD RBAC resources explicitly for the `role:platform` role
- Uses wildcard (`*`) for verbs instead of enumerating individual actions per resource
- Adds missing `logs` permission, required since ArgoCD 3.0 where logs RBAC is enforced by default
- Adds `exec` and `extensions` resources to cover the full admin surface
- Bumps chart version to `1.0.3`