### PR TITLE
fix(config): bump argocd to 1.0.4 and rook-ceph-cluster to 0.3.2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,12 +72,14 @@ All commits must follow the **Conventional Commits** specification.
 
 ### Rules
 
-- **Types**: `feat` (new feature), `fix` (bug fix)
-- **Scope**: Always required (e.g., `llm`, `ci`, `argocd`, `charts`)
+- **Types**: ONLY `feat` (new feature) or `fix` (bug fix). Never `chore` or any other type.
+- **Scope**: Always required. Must be one of:
+  - A directory name under `cmd/` (e.g. `cloud`, `nodeprofiler`, `tman`, `vllm-bench`)
+  - A hardcoded CI scope: `charts`, `ci`, `config`, `deps`, `tools`, `docs`, `llm`
 - **Description**: Written in imperative mood ("add feature", not "added" or "adds")
 - **PR Description**: NEVER include a test plan section, attribution to any AI assistant (Crush, OpenCode, Claude, etc.), or any other extra sections. A PR description must contain only a concise summary of the changes.
 
 ### Examples
 
 - `feat(llm): add gemma4 deployment config`
-- `fix(argocd): resolve authentication issue`
+- `fix(charts): expand ArgoCD RBAC platform role permissions`

--- a/deploy/clusters/prd-cph02/argocd/argocd.yml
+++ b/deploy/clusters/prd-cph02/argocd/argocd.yml
@@ -1,2 +1,2 @@
 chart: argocd
-tag: 1.0.2
+tag: 1.0.4

--- a/deploy/clusters/prd-cph02/platform/rook-ceph-cluster.yml
+++ b/deploy/clusters/prd-cph02/platform/rook-ceph-cluster.yml
@@ -1,2 +1,2 @@
 chart: rook-ceph-cluster
-tag: 0.3.0
+tag: 0.3.2


### PR DESCRIPTION
## Summary

- Bumps `argocd` deploy ref from `1.0.2` → `1.0.4`
- Bumps `rook-ceph-cluster` deploy ref from `0.3.0` → `0.3.2`

Tracks chart changes from #275.