### PR TITLE
fix(charts): fix oauth2-proxy config for ceph dashboard OIDC

### DIFF
--- a/charts/rook-ceph-cluster/Chart.yaml
+++ b/charts/rook-ceph-cluster/Chart.yaml
@@ -3,7 +3,7 @@ name: rook-ceph-cluster
 description: A Helm chart to deploy a Rook Ceph Cluster
 icon: https://upload.wikimedia.org/wikipedia/commons/0/07/Ceph_Logo_Stacked_RGB.png
 type: application
-version: 0.3.2
+version: 0.3.3
 appVersion: "1.19.5"
 dependencies:
   - repository: https://charts.rook.io/release

--- a/charts/rook-ceph-cluster/values.yaml
+++ b/charts/rook-ceph-cluster/values.yaml
@@ -57,7 +57,8 @@ oauth2-proxy:
     - --provider=oidc
     - --code-challenge-method=S256
     - --oidc-issuer-url=https://auth.nicklasfrahm.dev
-    - --client-secret=
+    - --client-id=ceph-dashboard
+    - --client-secret=unused
     - --oidc-groups-claim=groups
     - --skip-provider-button=true
     - --pass-authorization-header=true

--- a/charts/rook-ceph-cluster/values.yaml
+++ b/charts/rook-ceph-cluster/values.yaml
@@ -58,7 +58,7 @@ oauth2-proxy:
     - --code-challenge-method=S256
     - --oidc-issuer-url=https://auth.nicklasfrahm.dev
     - --client-id=ceph-dashboard
-    - --client-secret=unused
+    - --client-secret-file=/dev/null
     - --oidc-groups-claim=groups
     - --skip-provider-button=true
     - --pass-authorization-header=true

--- a/charts/rook-ceph-cluster/values.yaml
+++ b/charts/rook-ceph-cluster/values.yaml
@@ -58,6 +58,8 @@ oauth2-proxy:
     - --code-challenge-method=S256
     - --oidc-issuer-url=https://auth.nicklasfrahm.dev
     - --client-id=ceph-dashboard
+    # oauth2-proxy requires a client secret even for public PKCE clients, /dev/null is the workaround:
+    # https://github.com/oauth2-proxy/oauth2-proxy/issues/1714
     - --client-secret-file=/dev/null
     - --oidc-groups-claim=groups
     - --skip-provider-button=true

--- a/deploy/clusters/prd-cph02/platform/rook-ceph-cluster.yml
+++ b/deploy/clusters/prd-cph02/platform/rook-ceph-cluster.yml
@@ -1,2 +1,2 @@
 chart: rook-ceph-cluster
-tag: 0.3.2
+tag: 0.3.3

--- a/deploy/services/rook-ceph-cluster/20-cluster-prd-cph02.yml
+++ b/deploy/services/rook-ceph-cluster/20-cluster-prd-cph02.yml
@@ -208,7 +208,6 @@ oauth2-proxy:
     - --set-xauthrequest=true
   resources:
     limits:
-      cpu: "50m"
       memory: "128Mi"
     requests:
       cpu: "50m"

--- a/deploy/services/rook-ceph-cluster/20-cluster-prd-cph02.yml
+++ b/deploy/services/rook-ceph-cluster/20-cluster-prd-cph02.yml
@@ -200,7 +200,7 @@ oauth2-proxy:
     - --code-challenge-method=S256
     - --oidc-issuer-url=https://auth.nicklasfrahm.dev
     - --client-id=ceph-dashboard
-    - --client-secret=unused
+    - --client-secret-file=/dev/null
     - --oidc-groups-claim=groups
     - --allowed-group=nicklasfrahm-dev:platform
     - --skip-provider-button=true

--- a/deploy/services/rook-ceph-cluster/20-cluster-prd-cph02.yml
+++ b/deploy/services/rook-ceph-cluster/20-cluster-prd-cph02.yml
@@ -199,7 +199,8 @@ oauth2-proxy:
     - --provider=oidc
     - --code-challenge-method=S256
     - --oidc-issuer-url=https://auth.nicklasfrahm.dev
-    - --client-secret=
+    - --client-id=ceph-dashboard
+    - --client-secret=unused
     - --oidc-groups-claim=groups
     - --allowed-group=nicklasfrahm-dev:platform
     - --skip-provider-button=true
@@ -207,6 +208,7 @@ oauth2-proxy:
     - --set-xauthrequest=true
   resources:
     limits:
+      cpu: "50m"
       memory: "128Mi"
     requests:
       cpu: "50m"


### PR DESCRIPTION
## Summary

- Pass `--client-id=ceph-dashboard` via `extraArgs` since the Dex client is public (PKCE); the `clientID` chart value is not injected without adding `client-id` to `requiredSecretKeys`
- Use `--client-secret-file=/dev/null` to satisfy oauth2-proxy's mandatory client secret validation for public PKCE clients (see [oauth2-proxy/oauth2-proxy#1714](https://github.com/oauth2-proxy/oauth2-proxy/issues/1714))
- Fix `cookie-secret` in the `ceph-dashboard-proxy` k8s secret: was 44 bytes (a raw base64 string), replaced with a 32-byte value to satisfy oauth2-proxy's AES cipher requirement
- Bump chart version to `0.3.3`