### PR TITLE
fix(charts): remove invalid ceph dashboard sso oauth2 command

### DIFF
--- a/charts/rook-ceph-cluster/Chart.yaml
+++ b/charts/rook-ceph-cluster/Chart.yaml
@@ -3,7 +3,7 @@ name: rook-ceph-cluster
 description: A Helm chart to deploy a Rook Ceph Cluster
 icon: https://upload.wikimedia.org/wikipedia/commons/0/07/Ceph_Logo_Stacked_RGB.png
 type: application
-version: 0.3.3
+version: 0.3.4
 appVersion: "1.19.5"
 dependencies:
   - repository: https://charts.rook.io/release

--- a/charts/rook-ceph-cluster/templates/ceph-dashboard-setup-job.yaml
+++ b/charts/rook-ceph-cluster/templates/ceph-dashboard-setup-job.yaml
@@ -41,9 +41,6 @@ spec:
               key = $(cat /var/lib/rook-ceph-mon/secret.keyring)
               EOF
 
-              echo "Enabling OAuth2 SSO on Ceph Dashboard..."
-              ceph dashboard sso enable oauth2
-
               DESIRED_USERS=(
               {{- range $proxy.ssoSetup.adminUsers }}
                 {{ . }}

--- a/deploy/clusters/prd-cph02/platform/rook-ceph-cluster.yml
+++ b/deploy/clusters/prd-cph02/platform/rook-ceph-cluster.yml
@@ -1,2 +1,2 @@
 chart: rook-ceph-cluster
-tag: 0.3.3
+tag: 0.3.4


### PR DESCRIPTION
## Summary

- Remove `ceph dashboard sso enable oauth2` from the SSO setup job — this command does not exist; Ceph Dashboard's built-in SSO only supports SAML2
- Authentication is handled entirely by oauth2-proxy as a reverse proxy; no SSO setup command is needed on the dashboard side
- Bump chart to `0.3.4`