### PR TITLE
feat(charts): upgrade Ceph to v20.2.1 with OAuth2 SSO

### DIFF
--- a/charts/rook-ceph-cluster/Chart.yaml
+++ b/charts/rook-ceph-cluster/Chart.yaml
@@ -3,8 +3,8 @@ name: rook-ceph-cluster
 description: A Helm chart to deploy a Rook Ceph Cluster
 icon: https://upload.wikimedia.org/wikipedia/commons/0/07/Ceph_Logo_Stacked_RGB.png
 type: application
-version: 0.3.3
-appVersion: "1.19.5"
+version: 0.3.4
+appVersion: "20.2.1"
 dependencies:
   - repository: https://charts.rook.io/release
     name: rook-ceph-cluster

--- a/charts/rook-ceph-cluster/values.yaml
+++ b/charts/rook-ceph-cluster/values.yaml
@@ -1,5 +1,7 @@
 rook-ceph-cluster:
   enabled: true
+  cephImage:
+    tag: v20.2.1
   toolbox:
     enabled: true
     resources:
@@ -47,12 +49,23 @@ oauth2-proxy:
   ingress:
     enabled: false
   config:
-    clientID: ceph-dashboard
     existingSecret: ceph-dashboard-proxy
     requiredSecretKeys:
       - cookie-secret
     emailDomains:
       - "*"
+  alphaConfig:
+    enabled: true
+    configData:
+      upstreamConfig:
+        upstreams:
+          - id: dashboard
+            uri: http://rook-ceph-mgr-dashboard:7000
+            path: /
+      injectRequestHeaders:
+        - name: X-Access-Token
+          values:
+            - claim: access_token
   extraArgs:
     - --provider=oidc
     - --code-challenge-method=S256
@@ -63,8 +76,6 @@ oauth2-proxy:
     - --client-secret-file=/dev/null
     - --oidc-groups-claim=groups
     - --skip-provider-button=true
-    - --pass-authorization-header=true
-    - --set-xauthrequest=true
   httpRoute:
     enabled: true
     gateway:
@@ -74,7 +85,7 @@ oauth2-proxy:
   ssoSetup:
     enabled: true
     # Image must match the running Ceph cluster version.
-    image: quay.io/ceph/ceph:v19.2.3
+    image: quay.io/ceph/ceph:v20.2.1
     # GitHub usernames to pre-create as Ceph Dashboard administrators.
     adminUsers: []
     # Names of the Rook-generated secret and configmap used to reach the MONs.

--- a/deploy/clusters/prd-cph02/platform/rook-ceph-cluster.yml
+++ b/deploy/clusters/prd-cph02/platform/rook-ceph-cluster.yml
@@ -1,2 +1,2 @@
 chart: rook-ceph-cluster
-tag: 0.3.3
+tag: 0.3.4

--- a/deploy/services/rook-ceph-cluster/20-cluster-prd-cph02.yml
+++ b/deploy/services/rook-ceph-cluster/20-cluster-prd-cph02.yml
@@ -1,6 +1,9 @@
 rook-ceph-cluster:
   operatorNamespace: "platform"
 
+  cephImage:
+    tag: v20.2.1
+
   cephClusterSpec:
     # To control where various services will be scheduled by kubernetes, use the placement configuration sections below.
     # The example under 'all' would have all services scheduled on kubernetes nodes labeled with 'role=storage-node' and
@@ -192,9 +195,6 @@ rook-ceph-cluster:
 
 oauth2-proxy:
   enabled: true
-  config:
-    upstreams:
-      - http://rook-ceph-mgr-dashboard:7000
   extraArgs:
     - --provider=oidc
     - --code-challenge-method=S256
@@ -204,8 +204,6 @@ oauth2-proxy:
     - --oidc-groups-claim=groups
     - --allowed-group=nicklasfrahm-dev:platform
     - --skip-provider-button=true
-    - --pass-authorization-header=true
-    - --set-xauthrequest=true
   resources:
     limits:
       memory: "128Mi"


### PR DESCRIPTION
## Summary

- Upgrade Ceph from v19.2.3 (Squid) to **v20.2.1 (Tentacle)**, which is the first version to support `ceph dashboard sso enable oauth2`
- Switch oauth2-proxy to **alpha config** to inject an `X-Access-Token` request header (containing the OIDC access token) when forwarding to the Ceph Dashboard — this is how the dashboard authenticates the user without showing its own login page (mirrors the nginx `auth_request` pattern used by Cephadm's mgmt-gateway)
- Move upstream config from `config.upstreams` to `alphaConfig.configData.upstreamConfig` (required when alpha config is enabled)
- Remove `--pass-authorization-header` and `--set-xauthrequest` — superseded by the explicit header injection
- The setup job still creates admin users with the `administrator` role; the dashboard matches them by the `sub` claim (= GitHub username from Dex)

## How it works

```
User → Gateway → oauth2-proxy (authenticates via Dex/PKCE)
                       ↓ injects X-Access-Token: <oidc_access_token>
               Ceph Dashboard (sso_oauth2=true)
                       ↓ decodes JWT, skips sig verification (trusts proxy)
                       ↓ extracts sub → looks up user → loads role
                       ↓ redirects to /#/login?access_token=<token>
               Angular stores token, uses for API calls
```

## References

- [oauth2-proxy issue #1714](https://github.com/oauth2-proxy/oauth2-proxy/issues/1714) — client secret required even for public PKCE clients
- [Ceph Dashboard OAuth2 SSO docs](https://docs.ceph.com/en/latest/mgr/dashboard/#enabling-oauth2-single-sign-on-sso)