### PR TITLE
fix(charts): move oauth2-proxy provider config to alpha config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,11 @@ All commits must follow the **Conventional Commits** specification.
 - **Description**: Written in imperative mood ("add feature", not "added" or "adds")
 - **PR Description**: NEVER include a test plan section, attribution to any AI assistant (Crush, OpenCode, Claude, etc.), or any other extra sections. A PR description must contain only a concise summary of the changes.
 
+### Pull Requests
+
+- **Always create a PR.** Never push commits directly to `main`. Branch protection is enforced — direct pushes will be rejected.
+- Create a branch, push it, and open a PR via `gh pr create`.
+
 ### Examples
 
 - `feat(llm): add gemma4 deployment config`

--- a/charts/rook-ceph-cluster/Chart.yaml
+++ b/charts/rook-ceph-cluster/Chart.yaml
@@ -3,7 +3,7 @@ name: rook-ceph-cluster
 description: A Helm chart to deploy a Rook Ceph Cluster
 icon: https://upload.wikimedia.org/wikipedia/commons/0/07/Ceph_Logo_Stacked_RGB.png
 type: application
-version: 0.3.4
+version: 0.3.5
 appVersion: "20.2.1"
 dependencies:
   - repository: https://charts.rook.io/release

--- a/charts/rook-ceph-cluster/values.yaml
+++ b/charts/rook-ceph-cluster/values.yaml
@@ -57,6 +57,18 @@ oauth2-proxy:
   alphaConfig:
     enabled: true
     configData:
+      providers:
+        - id: oidc
+          provider: oidc
+          clientId: ceph-dashboard
+          # oauth2-proxy requires a client secret even for public PKCE clients, /dev/null is the workaround:
+          # https://github.com/oauth2-proxy/oauth2-proxy/issues/1714
+          clientSecretFile: /dev/null
+          oidcConfig:
+            issuerURL: https://auth.nicklasfrahm.dev
+            groupsClaim: groups
+          codeChallenge:
+            method: S256
       upstreamConfig:
         upstreams:
           - id: dashboard
@@ -67,14 +79,6 @@ oauth2-proxy:
           values:
             - claim: access_token
   extraArgs:
-    - --provider=oidc
-    - --code-challenge-method=S256
-    - --oidc-issuer-url=https://auth.nicklasfrahm.dev
-    - --client-id=ceph-dashboard
-    # oauth2-proxy requires a client secret even for public PKCE clients, /dev/null is the workaround:
-    # https://github.com/oauth2-proxy/oauth2-proxy/issues/1714
-    - --client-secret-file=/dev/null
-    - --oidc-groups-claim=groups
     - --skip-provider-button=true
   httpRoute:
     enabled: true

--- a/deploy/clusters/prd-cph02/platform/rook-ceph-cluster.yml
+++ b/deploy/clusters/prd-cph02/platform/rook-ceph-cluster.yml
@@ -1,2 +1,2 @@
 chart: rook-ceph-cluster
-tag: 0.3.4
+tag: 0.3.5

--- a/deploy/services/rook-ceph-cluster/20-cluster-prd-cph02.yml
+++ b/deploy/services/rook-ceph-cluster/20-cluster-prd-cph02.yml
@@ -201,6 +201,8 @@ oauth2-proxy:
         - id: oidc
           provider: oidc
           clientId: ceph-dashboard
+          # oauth2-proxy requires a client secret even for public PKCE clients, /dev/null is the workaround:
+          # https://github.com/oauth2-proxy/oauth2-proxy/issues/1714
           clientSecretFile: /dev/null
           oidcConfig:
             issuerURL: https://auth.nicklasfrahm.dev

--- a/deploy/services/rook-ceph-cluster/20-cluster-prd-cph02.yml
+++ b/deploy/services/rook-ceph-cluster/20-cluster-prd-cph02.yml
@@ -195,15 +195,20 @@ rook-ceph-cluster:
 
 oauth2-proxy:
   enabled: true
-  extraArgs:
-    - --provider=oidc
-    - --code-challenge-method=S256
-    - --oidc-issuer-url=https://auth.nicklasfrahm.dev
-    - --client-id=ceph-dashboard
-    - --client-secret-file=/dev/null
-    - --oidc-groups-claim=groups
-    - --allowed-group=nicklasfrahm-dev:platform
-    - --skip-provider-button=true
+  alphaConfig:
+    configData:
+      providers:
+        - id: oidc
+          provider: oidc
+          clientId: ceph-dashboard
+          clientSecretFile: /dev/null
+          oidcConfig:
+            issuerURL: https://auth.nicklasfrahm.dev
+            groupsClaim: groups
+          codeChallenge:
+            method: S256
+          allowedGroups:
+            - nicklasfrahm-dev:platform
   resources:
     limits:
       memory: "128Mi"


### PR DESCRIPTION
## Summary

- Move all provider-related flags (`--provider`, `--oidc-issuer-url`, `--client-id`, `--client-secret-file`, `--code-challenge-method`, `--oidc-groups-claim`, `--allowed-group`) from `extraArgs` into `alphaConfig.configData.providers` — when alpha config is enabled, these CLI flags are rejected as unknown
- `allowedGroups` is set at the cluster level in the cluster values override
- Add a rule to `AGENTS.md` requiring all changes to go through PRs; direct pushes to `main` are rejected by branch protection