### PR TITLE
fix(charts): fix oauth2-proxy alpha config schema and upgrade Rook to v1.19.5

### DIFF
--- a/charts/rook-ceph-cluster/Chart.yaml
+++ b/charts/rook-ceph-cluster/Chart.yaml
@@ -3,7 +3,7 @@ name: rook-ceph-cluster
 description: A Helm chart to deploy a Rook Ceph Cluster
 icon: https://upload.wikimedia.org/wikipedia/commons/0/07/Ceph_Logo_Stacked_RGB.png
 type: application
-version: 0.3.5
+version: 0.3.6
 appVersion: "20.2.1"
 dependencies:
   - repository: https://charts.rook.io/release

--- a/charts/rook-ceph-cluster/Chart.yaml
+++ b/charts/rook-ceph-cluster/Chart.yaml
@@ -3,7 +3,7 @@ name: rook-ceph-cluster
 description: A Helm chart to deploy a Rook Ceph Cluster
 icon: https://upload.wikimedia.org/wikipedia/commons/0/07/Ceph_Logo_Stacked_RGB.png
 type: application
-version: 0.3.6
+version: 0.3.7
 appVersion: "20.2.1"
 dependencies:
   - repository: https://charts.rook.io/release

--- a/charts/rook-ceph-cluster/values.yaml
+++ b/charts/rook-ceph-cluster/values.yaml
@@ -2,6 +2,7 @@ rook-ceph-cluster:
   enabled: true
   cephImage:
     tag: v20.2.1
+    allowUnsupported: true
   toolbox:
     enabled: true
     resources:
@@ -67,8 +68,7 @@ oauth2-proxy:
           oidcConfig:
             issuerURL: https://auth.nicklasfrahm.dev
             groupsClaim: groups
-          codeChallenge:
-            method: S256
+          codeChallengeMethod: S256
       upstreamConfig:
         upstreams:
           - id: dashboard
@@ -77,7 +77,8 @@ oauth2-proxy:
       injectRequestHeaders:
         - name: X-Access-Token
           values:
-            - claim: access_token
+            - claimSource:
+                claim: access_token
   extraArgs:
     - --skip-provider-button=true
   httpRoute:

--- a/charts/rook-ceph-cluster/values.yaml
+++ b/charts/rook-ceph-cluster/values.yaml
@@ -2,7 +2,6 @@ rook-ceph-cluster:
   enabled: true
   cephImage:
     tag: v20.2.1
-    allowUnsupported: true
   toolbox:
     enabled: true
     resources:

--- a/charts/rook-ceph/Chart.yaml
+++ b/charts/rook-ceph/Chart.yaml
@@ -3,12 +3,12 @@ name: rook-ceph
 description: A Helm chart for the Rook Ceph Operator
 icon: https://upload.wikimedia.org/wikipedia/commons/0/07/Ceph_Logo_Stacked_RGB.png
 type: application
-version: 0.2.0
-appVersion: "1.18.7"
+version: 0.2.1
+appVersion: "1.19.5"
 dependencies:
   - repository: https://charts.rook.io/release
     name: rook-ceph
-    version: 1.18.7
+    version: 1.19.5
     condition: rook-ceph.enabled
     tags:
       - storage

--- a/deploy/clusters/prd-cph02/platform/rook-ceph-cluster.yml
+++ b/deploy/clusters/prd-cph02/platform/rook-ceph-cluster.yml
@@ -1,2 +1,2 @@
 chart: rook-ceph-cluster
-tag: 0.3.6
+tag: 0.3.7

--- a/deploy/clusters/prd-cph02/platform/rook-ceph-cluster.yml
+++ b/deploy/clusters/prd-cph02/platform/rook-ceph-cluster.yml
@@ -1,2 +1,2 @@
 chart: rook-ceph-cluster
-tag: 0.3.5
+tag: 0.3.6

--- a/deploy/clusters/prd-cph02/platform/rook-ceph.yml
+++ b/deploy/clusters/prd-cph02/platform/rook-ceph.yml
@@ -1,2 +1,2 @@
 chart: rook-ceph
-tag: 0.2.0
+tag: 0.2.1

--- a/deploy/services/rook-ceph-cluster/20-cluster-prd-cph02.yml
+++ b/deploy/services/rook-ceph-cluster/20-cluster-prd-cph02.yml
@@ -3,7 +3,6 @@ rook-ceph-cluster:
 
   cephImage:
     tag: v20.2.1
-    allowUnsupported: true
 
   cephClusterSpec:
     # To control where various services will be scheduled by kubernetes, use the placement configuration sections below.

--- a/deploy/services/rook-ceph-cluster/20-cluster-prd-cph02.yml
+++ b/deploy/services/rook-ceph-cluster/20-cluster-prd-cph02.yml
@@ -3,6 +3,7 @@ rook-ceph-cluster:
 
   cephImage:
     tag: v20.2.1
+    allowUnsupported: true
 
   cephClusterSpec:
     # To control where various services will be scheduled by kubernetes, use the placement configuration sections below.
@@ -207,8 +208,7 @@ oauth2-proxy:
           oidcConfig:
             issuerURL: https://auth.nicklasfrahm.dev
             groupsClaim: groups
-          codeChallenge:
-            method: S256
+          codeChallengeMethod: S256
           allowedGroups:
             - nicklasfrahm-dev:platform
   resources:


### PR DESCRIPTION
## Summary

- Fix two alpha config schema errors:
  - `codeChallenge.method` → `codeChallengeMethod` (flat field on provider)
  - `values[].claim` → `values[].claimSource.claim` (claim must be nested under `claimSource`)
- Upgrade Rook operator from v1.18.7 to v1.19.5, which officially supports Ceph Tentacle (v20); removes the need for `allowUnsupported: true`
- Bump rook-ceph chart to 0.2.1 and rook-ceph-cluster chart to 0.3.7