### PR TITLE
fix(charts): move code-challenge-method back to extraArgs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,11 @@ All commits must follow the **Conventional Commits** specification.
 - **Always create a PR.** Never push commits directly to `main`. Branch protection is enforced — direct pushes will be rejected.
 - Create a branch, push it, and open a PR via `gh pr create`.
 
+### Helm Charts
+
+- **Always bump the chart version** (`version` in `Chart.yaml`) when making any change to a chart.
+- **Always update the deploy tag** (`tag` in `deploy/clusters/<cluster>/platform/<chart>.yml`) to match the new chart version.
+
 ### Examples
 
 - `feat(llm): add gemma4 deployment config`

--- a/charts/rook-ceph-cluster/Chart.yaml
+++ b/charts/rook-ceph-cluster/Chart.yaml
@@ -3,7 +3,7 @@ name: rook-ceph-cluster
 description: A Helm chart to deploy a Rook Ceph Cluster
 icon: https://upload.wikimedia.org/wikipedia/commons/0/07/Ceph_Logo_Stacked_RGB.png
 type: application
-version: 0.3.7
+version: 0.3.8
 appVersion: "20.2.1"
 dependencies:
   - repository: https://charts.rook.io/release

--- a/charts/rook-ceph-cluster/values.yaml
+++ b/charts/rook-ceph-cluster/values.yaml
@@ -67,7 +67,6 @@ oauth2-proxy:
           oidcConfig:
             issuerURL: https://auth.nicklasfrahm.dev
             groupsClaim: groups
-          codeChallengeMethod: S256
       upstreamConfig:
         upstreams:
           - id: dashboard
@@ -79,6 +78,7 @@ oauth2-proxy:
             - claimSource:
                 claim: access_token
   extraArgs:
+    - --code-challenge-method=S256
     - --skip-provider-button=true
   httpRoute:
     enabled: true

--- a/deploy/clusters/prd-cph02/platform/rook-ceph-cluster.yml
+++ b/deploy/clusters/prd-cph02/platform/rook-ceph-cluster.yml
@@ -1,2 +1,2 @@
 chart: rook-ceph-cluster
-tag: 0.3.7
+tag: 0.3.8

--- a/deploy/services/rook-ceph-cluster/20-cluster-prd-cph02.yml
+++ b/deploy/services/rook-ceph-cluster/20-cluster-prd-cph02.yml
@@ -207,7 +207,6 @@ oauth2-proxy:
           oidcConfig:
             issuerURL: https://auth.nicklasfrahm.dev
             groupsClaim: groups
-          codeChallengeMethod: S256
           allowedGroups:
             - nicklasfrahm-dev:platform
   resources:


### PR DESCRIPTION
## Summary

`codeChallengeMethod` is not a valid field in the oauth2-proxy alpha config provider struct — the alpha config decoder rejects it. Move it back to `extraArgs` as `--code-challenge-method=S256`, which remains valid alongside alpha config.