### PR TITLE
fix(charts): fix oauth2-proxy alpha config schema

### DIFF
--- a/charts/rook-ceph-cluster/Chart.yaml
+++ b/charts/rook-ceph-cluster/Chart.yaml
@@ -3,7 +3,7 @@ name: rook-ceph-cluster
 description: A Helm chart to deploy a Rook Ceph Cluster
 icon: https://upload.wikimedia.org/wikipedia/commons/0/07/Ceph_Logo_Stacked_RGB.png
 type: application
-version: 0.3.8
+version: 0.3.9
 appVersion: "20.2.1"
 dependencies:
   - repository: https://charts.rook.io/release

--- a/charts/rook-ceph-cluster/values.yaml
+++ b/charts/rook-ceph-cluster/values.yaml
@@ -60,13 +60,14 @@ oauth2-proxy:
       providers:
         - id: oidc
           provider: oidc
-          clientId: ceph-dashboard
+          clientID: ceph-dashboard
           # oauth2-proxy requires a client secret even for public PKCE clients, /dev/null is the workaround:
           # https://github.com/oauth2-proxy/oauth2-proxy/issues/1714
           clientSecretFile: /dev/null
           oidcConfig:
             issuerURL: https://auth.nicklasfrahm.dev
             groupsClaim: groups
+          code_challenge_method: S256
       upstreamConfig:
         upstreams:
           - id: dashboard
@@ -78,7 +79,6 @@ oauth2-proxy:
             - claimSource:
                 claim: access_token
   extraArgs:
-    - --code-challenge-method=S256
     - --skip-provider-button=true
   httpRoute:
     enabled: true

--- a/deploy/clusters/prd-cph02/platform/rook-ceph-cluster.yml
+++ b/deploy/clusters/prd-cph02/platform/rook-ceph-cluster.yml
@@ -1,2 +1,2 @@
 chart: rook-ceph-cluster
-tag: 0.3.8
+tag: 0.3.9

--- a/deploy/services/rook-ceph-cluster/20-cluster-prd-cph02.yml
+++ b/deploy/services/rook-ceph-cluster/20-cluster-prd-cph02.yml
@@ -200,13 +200,14 @@ oauth2-proxy:
       providers:
         - id: oidc
           provider: oidc
-          clientId: ceph-dashboard
+          clientID: ceph-dashboard
           # oauth2-proxy requires a client secret even for public PKCE clients, /dev/null is the workaround:
           # https://github.com/oauth2-proxy/oauth2-proxy/issues/1714
           clientSecretFile: /dev/null
           oidcConfig:
             issuerURL: https://auth.nicklasfrahm.dev
             groupsClaim: groups
+          code_challenge_method: S256
           allowedGroups:
             - nicklasfrahm-dev:platform
   resources:


### PR DESCRIPTION
## Summary

`--code-challenge-method` is also rejected as a CLI flag when alpha config is enabled. The correct field is `code_challenge_method` (snake_case) on the provider in the alpha config, as defined in [`pkg/apis/options/providers.go`](https://github.com/oauth2-proxy/oauth2-proxy/blob/v7.15.2/pkg/apis/options/providers.go).

Move it from `extraArgs` into `alphaConfig.configData.providers[].code_challenge_method`. Bump chart to 0.3.9.