### PR TITLE
fix(config): increase mgr-sidecar memory limit to 128Mi

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,8 +86,9 @@ All commits must follow the **Conventional Commits** specification.
 
 ### Helm Charts
 
-- **Always bump the chart version** (`version` in `Chart.yaml`) when making any change to a chart.
+- **Always bump the chart version** (`version` in `Chart.yaml`) when making any change to a chart's templates or default values.
 - **Always update the deploy tag** (`tag` in `deploy/clusters/<cluster>/platform/<chart>.yml`) to match the new chart version.
+- **No bump needed** when only editing cluster-specific overrides under `deploy/services/` — those are values passed to an already-published chart version and do not change the chart itself.
 
 ### Examples
 

--- a/deploy/services/rook-ceph-cluster/20-cluster-prd-cph02.yml
+++ b/deploy/services/rook-ceph-cluster/20-cluster-prd-cph02.yml
@@ -42,10 +42,10 @@ rook-ceph-cluster:
           memory: "50Mi"
       mgr-sidecar:
         limits:
-          memory: "40Mi"
+          memory: "128Mi"
         requests:
           cpu: "100m"
-          memory: "40Mi"
+          memory: "128Mi"
       cleanup:
         limits:
           memory: "100Mi"


### PR DESCRIPTION
## Summary

The `watch-active` sidecar (configured via `mgr-sidecar` resources) OOMKills at 40Mi after upgrading to Rook v1.19.5 / Ceph v20.2.1. The new binary has a larger footprint than v1.18/v19. Bump memory limit and request to 128Mi.