### PR TITLE
fix(charts): fix oauth2-proxy HTTPRoute port from 4180 to 80

### DIFF
--- a/charts/rook-ceph-cluster/Chart.yaml
+++ b/charts/rook-ceph-cluster/Chart.yaml
@@ -3,7 +3,7 @@ name: rook-ceph-cluster
 description: A Helm chart to deploy a Rook Ceph Cluster
 icon: https://upload.wikimedia.org/wikipedia/commons/0/07/Ceph_Logo_Stacked_RGB.png
 type: application
-version: 0.3.9
+version: 0.3.10
 appVersion: "20.2.1"
 dependencies:
   - repository: https://charts.rook.io/release

--- a/charts/rook-ceph-cluster/templates/ceph-dashboard-httproute.yaml
+++ b/charts/rook-ceph-cluster/templates/ceph-dashboard-httproute.yaml
@@ -19,5 +19,5 @@ spec:
       backendRefs:
         - name: {{ printf "%s-oauth2-proxy" .Release.Name | quote }}
           namespace: {{ .Release.Namespace | quote }}
-          port: 4180
+          port: 80
 {{- end }}

--- a/deploy/clusters/prd-cph02/platform/rook-ceph-cluster.yml
+++ b/deploy/clusters/prd-cph02/platform/rook-ceph-cluster.yml
@@ -1,2 +1,2 @@
 chart: rook-ceph-cluster
-tag: 0.3.9
+tag: 0.3.10


### PR DESCRIPTION

## Summary

- Fixed the `port` field in the Ceph Dashboard HTTPRoute backend reference from `4180` to `80` (the correct oauth2-proxy port)
- Bumped rook-ceph-cluster chart version to `0.3.10` and updated the deploy tag in `prd-cph02`