### PR TITLE
fix(charts): inject id_token and configure roles_path for Ceph Dashboard OAuth2 SSO

### DIFF
--- a/charts/rook-ceph-cluster/Chart.yaml
+++ b/charts/rook-ceph-cluster/Chart.yaml
@@ -3,7 +3,7 @@ name: rook-ceph-cluster
 description: A Helm chart to deploy a Rook Ceph Cluster
 icon: https://upload.wikimedia.org/wikipedia/commons/0/07/Ceph_Logo_Stacked_RGB.png
 type: application
-version: 0.3.12
+version: 0.3.13
 appVersion: "20.2.1"
 dependencies:
   - repository: https://charts.rook.io/release

--- a/charts/rook-ceph-cluster/templates/ceph-dashboard-setup-job.yaml
+++ b/charts/rook-ceph-cluster/templates/ceph-dashboard-setup-job.yaml
@@ -41,8 +41,17 @@ spec:
               key = $(cat /var/lib/rook-ceph-mon/secret.keyring)
               EOF
 
+              {{- if $proxy.ssoSetup.rolesPath }}
+              ROLES_PATH=$(cat <<'ROLES_PATH_EOF'
+              {{ $proxy.ssoSetup.rolesPath }}
+              ROLES_PATH_EOF
+              )
+              echo "Enabling OAuth2 SSO on Ceph Dashboard with roles_path..."
+              ceph dashboard sso enable oauth2 "$ROLES_PATH"
+              {{- else }}
               echo "Enabling OAuth2 SSO on Ceph Dashboard..."
               ceph dashboard sso enable oauth2
+              {{- end }}
 
               {{- if $proxy.ssoSetup.telemetryOptIn }}
               echo "Opting in to Ceph telemetry..."

--- a/charts/rook-ceph-cluster/values.yaml
+++ b/charts/rook-ceph-cluster/values.yaml
@@ -77,7 +77,7 @@ oauth2-proxy:
         - name: X-Access-Token
           values:
             - claimSource:
-                claim: access_token
+                claim: id_token
   extraArgs:
     - --skip-provider-button=true
   httpRoute:
@@ -98,3 +98,6 @@ oauth2-proxy:
     # Set to true to opt in to Ceph telemetry (requires accepting the sharing license).
     # Defaults to false to suppress HEALTH_WARN "Telemetry requires re-opt-in".
     telemetryOptIn: false
+    # JMESPath expression to extract roles from the JWT. If empty, role extraction is skipped.
+    # Example: contains(groups[*], 'org:team') && `["administrator"]` || `[]`
+    rolesPath: ""

--- a/deploy/clusters/prd-cph02/platform/rook-ceph-cluster.yml
+++ b/deploy/clusters/prd-cph02/platform/rook-ceph-cluster.yml
@@ -1,2 +1,2 @@
 chart: rook-ceph-cluster
-tag: 0.3.12
+tag: 0.3.13

--- a/deploy/services/rook-ceph-cluster/20-cluster-prd-cph02.yml
+++ b/deploy/services/rook-ceph-cluster/20-cluster-prd-cph02.yml
@@ -225,3 +225,4 @@ oauth2-proxy:
     telemetryOptIn: true
     adminUsers:
       - nicklasfrahm
+    rolesPath: 'contains(groups[*], ''nicklasfrahm-dev:platform'') && `["administrator"]` || `[]`'

--- a/deploy/services/rook-ceph-cluster/20-cluster-prd-cph02.yml
+++ b/deploy/services/rook-ceph-cluster/20-cluster-prd-cph02.yml
@@ -225,4 +225,4 @@ oauth2-proxy:
     telemetryOptIn: true
     adminUsers:
       - nicklasfrahm
-    rolesPath: 'contains(groups[*], ''nicklasfrahm-dev:platform'') && `["administrator"]` || `[]`'
+    rolesPath: "contains(groups[*], 'nicklasfrahm-dev:platform') && `[\"administrator\"]` || `[]`"


### PR DESCRIPTION
Two bugs caused all Ceph Dashboard API requests proxied through oauth2-proxy to return 500:

- oauth2-proxy was injecting `X-Access-Token` using `claim: access_token` (an opaque token). Ceph Dashboard's OAuth2 handler calls `decode_jwt_segment(token.split(".")[1])`, which raises `IndexError` on a non-JWT. Fixed by switching to `claim: id_token`, which is a valid JWT issued by Dex.
- `roles_path` was not configured, so `get_user_roles()` found no roles in the JWT and raised a 403. Fixed by passing a JMESPath expression to `ceph dashboard sso enable oauth2` that maps membership in the `nicklasfrahm-dev:platform` GitHub org team to the `administrator` role.