### PR TITLE
fix(charts): fix Ceph Dashboard SSO identity propagation via proxy headers

### DIFF
--- a/charts/rook-ceph-cluster/Chart.yaml
+++ b/charts/rook-ceph-cluster/Chart.yaml
@@ -3,7 +3,7 @@ name: rook-ceph-cluster
 description: A Helm chart to deploy a Rook Ceph Cluster
 icon: https://upload.wikimedia.org/wikipedia/commons/0/07/Ceph_Logo_Stacked_RGB.png
 type: application
-version: 0.3.13
+version: 0.3.14
 appVersion: "20.2.1"
 dependencies:
   - repository: https://charts.rook.io/release

--- a/charts/rook-ceph-cluster/values.yaml
+++ b/charts/rook-ceph-cluster/values.yaml
@@ -74,12 +74,21 @@ oauth2-proxy:
             uri: http://rook-ceph-mgr-dashboard:7000
             path: /
       injectRequestHeaders:
-        - name: X-Access-Token
+        - name: X-Forwarded-User
           values:
             - claimSource:
-                claim: id_token
+                claim: user
+        - name: X-Forwarded-Email
+          values:
+            - claimSource:
+                claim: email
   extraArgs:
     - --skip-provider-button=true
+    - --reverse-proxy=true
+    - --set-xauthrequest=true
+    - --pass-access-token=true
+    - --pass-authorization-header=true
+    - --pass-user-headers=true
   httpRoute:
     enabled: true
     gateway:

--- a/deploy/clusters/prd-cph02/platform/rook-ceph-cluster.yml
+++ b/deploy/clusters/prd-cph02/platform/rook-ceph-cluster.yml
@@ -1,2 +1,2 @@
 chart: rook-ceph-cluster
-tag: 0.3.13
+tag: 0.3.14


### PR DESCRIPTION
Replace the fragile JWT token forwarding path with stable cephadm-style identity headers, and add the five required oauth2-proxy flags to ensure identity propagates correctly from oauth2-proxy into Ceph Dashboard.

- Replace `X-Access-Token`/`id_token` injection with `X-Forwarded-User` and `X-Forwarded-Email` headers, which Ceph Dashboard trusts as the primary identity source
- Add `--reverse-proxy`, `--set-xauthrequest`, `--pass-access-token`, `--pass-authorization-header`, and `--pass-user-headers` flags to oauth2-proxy
- Bump chart to `0.3.14` and update `prd-cph02` deploy tag accordingly