### PR TITLE
fix(charts): remove invalid oauth2-proxy CLI flags unsupported in alpha config mode

### DIFF
--- a/charts/rook-ceph-cluster/Chart.yaml
+++ b/charts/rook-ceph-cluster/Chart.yaml
@@ -3,7 +3,7 @@ name: rook-ceph-cluster
 description: A Helm chart to deploy a Rook Ceph Cluster
 icon: https://upload.wikimedia.org/wikipedia/commons/0/07/Ceph_Logo_Stacked_RGB.png
 type: application
-version: 0.3.14
+version: 0.3.15
 appVersion: "20.2.1"
 dependencies:
   - repository: https://charts.rook.io/release

--- a/charts/rook-ceph-cluster/values.yaml
+++ b/charts/rook-ceph-cluster/values.yaml
@@ -85,10 +85,6 @@ oauth2-proxy:
   extraArgs:
     - --skip-provider-button=true
     - --reverse-proxy=true
-    - --set-xauthrequest=true
-    - --pass-access-token=true
-    - --pass-authorization-header=true
-    - --pass-user-headers=true
   httpRoute:
     enabled: true
     gateway:

--- a/deploy/clusters/prd-cph02/platform/rook-ceph-cluster.yml
+++ b/deploy/clusters/prd-cph02/platform/rook-ceph-cluster.yml
@@ -1,2 +1,2 @@
 chart: rook-ceph-cluster
-tag: 0.3.14
+tag: 0.3.15


### PR DESCRIPTION
oauth2-proxy crashed on startup with `unknown flag: --set-xauthrequest` because the flags added in #289 do not exist as CLI arguments in this version of oauth2-proxy when alpha config is active — that functionality is configured via `alphaConfig.configData.injectRequestHeaders` instead.

- Remove `--set-xauthrequest`, `--pass-access-token`, `--pass-authorization-header`, and `--pass-user-headers` from `extraArgs`
- Keep `--reverse-proxy=true`, which is a valid CLI flag in this version (confirmed in the help output)
- Bump chart to `0.3.15` and update `prd-cph02` deploy tag accordingly