### PR TITLE
fix(charts): fix Ceph Dashboard SSO oauth2-proxy alpha config

### DIFF
--- a/charts/rook-ceph-cluster/Chart.yaml
+++ b/charts/rook-ceph-cluster/Chart.yaml
@@ -3,7 +3,7 @@ name: rook-ceph-cluster
 description: A Helm chart to deploy a Rook Ceph Cluster
 icon: https://upload.wikimedia.org/wikipedia/commons/0/07/Ceph_Logo_Stacked_RGB.png
 type: application
-version: 0.3.15
+version: 0.3.16
 appVersion: "20.2.1"
 dependencies:
   - repository: https://charts.rook.io/release

--- a/charts/rook-ceph-cluster/values.yaml
+++ b/charts/rook-ceph-cluster/values.yaml
@@ -82,6 +82,11 @@ oauth2-proxy:
           values:
             - claimSource:
                 claim: email
+        - name: Authorization
+          values:
+            - prefix: "Bearer "
+              tokenSource:
+                token: id_token
   extraArgs:
     - --skip-provider-button=true
     - --reverse-proxy=true

--- a/deploy/clusters/prd-cph02/platform/rook-ceph-cluster.yml
+++ b/deploy/clusters/prd-cph02/platform/rook-ceph-cluster.yml
@@ -1,2 +1,2 @@
 chart: rook-ceph-cluster
-tag: 0.3.15
+tag: 0.3.16


### PR DESCRIPTION
## Summary

- Removes invalid CLI flags (`--set-xauthrequest`, `--pass-access-token`, `--pass-authorization-header`, `--pass-user-headers`) unsupported in oauth2-proxy alpha config mode
- Adds `X-Forwarded-User` and `X-Forwarded-Email` header injection via `injectRequestHeaders` for Ceph's preferred cephadm-style identity propagation
- Restores `Authorization: Bearer <id_token>` forwarding using the alpha config `tokenSource` syntax, required for Ceph to evaluate the `rolesPath` JMESPath expression against JWT claims