### PR TITLE
fix(charts): disable oauth2-proxy in Ceph cluster chart

### DIFF
--- a/charts/rook-ceph-cluster/Chart.yaml
+++ b/charts/rook-ceph-cluster/Chart.yaml
@@ -3,7 +3,7 @@ name: rook-ceph-cluster
 description: A Helm chart to deploy a Rook Ceph Cluster
 icon: https://upload.wikimedia.org/wikipedia/commons/0/07/Ceph_Logo_Stacked_RGB.png
 type: application
-version: 0.3.16
+version: 0.3.17
 appVersion: "20.2.1"
 dependencies:
   - repository: https://charts.rook.io/release

--- a/deploy/clusters/prd-cph02/platform/rook-ceph-cluster.yml
+++ b/deploy/clusters/prd-cph02/platform/rook-ceph-cluster.yml
@@ -1,2 +1,2 @@
 chart: rook-ceph-cluster
-tag: 0.3.16
+tag: 0.3.17

--- a/deploy/services/rook-ceph-cluster/20-cluster-prd-cph02.yml
+++ b/deploy/services/rook-ceph-cluster/20-cluster-prd-cph02.yml
@@ -194,7 +194,7 @@ rook-ceph-cluster:
             name: shared-http
 
 oauth2-proxy:
-  enabled: true
+  enabled: false
   alphaConfig:
     configData:
       providers:


### PR DESCRIPTION
## Summary

- Disables oauth2-proxy in the Ceph cluster chart while a standalone proxy chart is built and validated locally before re-integration