### PR TITLE
fix(config): disable oauth2-proxy for Ceph Dashboard on prd-cph02

### DIFF
--- a/deploy/services/rook-ceph-cluster/20-cluster-prd-cph02.yml
+++ b/deploy/services/rook-ceph-cluster/20-cluster-prd-cph02.yml
@@ -194,7 +194,7 @@ rook-ceph-cluster:
             name: shared-http
 
 oauth2-proxy:
-  enabled: true
+  enabled: false
   alphaConfig:
     configData:
       providers:


### PR DESCRIPTION
## Summary

- Disables oauth2-proxy in the prd-cph02 cluster config while a standalone proxy chart is built and validated locally before re-integration