### PR TITLE
feat(charts): integrate Ceph Dashboard SSO proxy into rook-ceph-cluster

### DIFF
--- a/charts/rook-ceph-cluster/Chart.yaml
+++ b/charts/rook-ceph-cluster/Chart.yaml
@@ -3,7 +3,7 @@ name: rook-ceph-cluster
 description: A Helm chart to deploy a Rook Ceph Cluster
 icon: https://upload.wikimedia.org/wikipedia/commons/0/07/Ceph_Logo_Stacked_RGB.png
 type: application
-version: 0.3.16
+version: 0.3.17
 appVersion: "20.2.1"
 dependencies:
   - repository: https://charts.rook.io/release

--- a/charts/rook-ceph-cluster/templates/ceph-dashboard-httproute.yaml
+++ b/charts/rook-ceph-cluster/templates/ceph-dashboard-httproute.yaml
@@ -3,8 +3,13 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: {{ printf "%s" .Release.Name | quote }}
+  name: {{ printf "%s-ceph-dashboard" .Release.Name | quote }}
   namespace: {{ .Release.Namespace | quote }}
+  labels:
+    helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | quote }}
+    app.kubernetes.io/name: "ceph-dashboard"
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 spec:
   parentRefs:
     - namespace: {{ $proxy.httpRoute.gateway.namespace | quote }}

--- a/charts/rook-ceph-cluster/templates/ceph-dashboard-jti-injector-configmap.yaml
+++ b/charts/rook-ceph-cluster/templates/ceph-dashboard-jti-injector-configmap.yaml
@@ -1,0 +1,80 @@
+{{- $proxy := index .Values "oauth2-proxy" }}
+{{- if $proxy.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ printf "%s-jti-injector" .Release.Name | quote }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | quote }}
+    app.kubernetes.io/name: "ceph-dashboard"
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+data:
+  nginx.conf: |
+    worker_processes 1;
+    error_log /dev/stderr warn;
+    pid /tmp/nginx.pid;
+
+    events {
+      worker_connections 64;
+    }
+
+    http {
+      access_log /dev/stdout;
+      client_body_temp_path /tmp/client_body;
+      proxy_temp_path /tmp/proxy;
+
+      server {
+        listen 8080;
+
+        location / {
+          rewrite_by_lua_block {
+            local token = ngx.req.get_headers()["X-Access-Token"]
+            if not token then return end
+
+            local parts = {}
+            for p in token:gmatch("[^.]+") do
+              table.insert(parts, p)
+            end
+            if #parts ~= 3 then return end
+
+            local function b64url_decode(s)
+              s = s:gsub('-', '+'):gsub('_', '/')
+              local pad = 4 - (#s % 4)
+              if pad < 4 then s = s .. string.rep('=', pad) end
+              return ngx.decode_base64(s)
+            end
+
+            local function b64url_encode(s)
+              return ngx.encode_base64(s):gsub('+', '-'):gsub('/', '_'):gsub('=', '')
+            end
+
+            local cjson = require "cjson.safe"
+            local payload_json = b64url_decode(parts[2])
+            if not payload_json then return end
+
+            local payload = cjson.decode(payload_json)
+            if not payload then return end
+
+            local modified = false
+            if not payload.jti then
+              payload.jti = ngx.md5(token)
+              modified = true
+            end
+            if payload.preferred_username then
+              payload.sub = payload.preferred_username
+              modified = true
+            end
+            if not modified then return end
+
+            ngx.req.set_header("X-Access-Token",
+              parts[1] .. "." .. b64url_encode(cjson.encode(payload)) .. "." .. parts[3])
+          }
+
+          proxy_pass {{ $proxy.dashboardUpstream }};
+          proxy_set_header Host $http_host;
+        }
+      }
+    }
+{{- end }}

--- a/charts/rook-ceph-cluster/templates/ceph-dashboard-sso-setup.yaml
+++ b/charts/rook-ceph-cluster/templates/ceph-dashboard-sso-setup.yaml
@@ -3,8 +3,13 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ printf "%s-sso-setup" .Release.Name | quote }}
+  name: {{ printf "%s-ceph-dashboard-sso-setup" .Release.Name | quote }}
   namespace: {{ .Release.Namespace | quote }}
+  labels:
+    helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | quote }}
+    app.kubernetes.io/name: "ceph-dashboard"
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
   annotations:
     helm.sh/hook: post-install,post-upgrade
     helm.sh/hook-delete-policy: before-hook-creation
@@ -41,9 +46,14 @@ spec:
               key = $(cat /var/lib/rook-ceph-mon/secret.keyring)
               EOF
 
-              {{- if $proxy.ssoSetup.rolesPath }}
+              {{- $parts := list -}}
+              {{- range $proxy.ssoSetup.groupRoles -}}
+                {{- $part := printf "contains(groups[*], '%s') && `%s`" .group (.roles | toJson) -}}
+                {{- $parts = append $parts $part -}}
+              {{- end -}}
+              {{- if $parts }}
               ROLES_PATH=$(cat <<'ROLES_PATH_EOF'
-              {{ $proxy.ssoSetup.rolesPath }}
+              {{ join " || " $parts }} || `[]`
               ROLES_PATH_EOF
               )
               echo "Enabling OAuth2 SSO on Ceph Dashboard with roles_path..."
@@ -60,39 +70,6 @@ spec:
               echo "Opting out of Ceph telemetry..."
               ceph telemetry off
               {{- end }}
-
-              DESIRED_USERS=(
-              {{- range $proxy.ssoSetup.adminUsers }}
-                {{ . }}
-              {{- end }}
-              )
-
-              {{- range $proxy.ssoSetup.adminUsers }}
-              echo "Ensuring admin user {{ . }} exists..."
-              if ceph dashboard ac-user-show {{ . | quote }} > /dev/null 2>&1; then
-                echo "User {{ . }} already exists, updating roles..."
-                ceph dashboard ac-user-set-roles {{ . | quote }} administrator > /dev/null
-              else
-                echo "Creating user {{ . }}..."
-                openssl rand -base64 32 | \
-                  ceph dashboard ac-user-create {{ . | quote }} -i /dev/stdin administrator > /dev/null
-              fi
-              {{- end }}
-
-              echo "Removing stale admin users..."
-              current_users=$(ceph dashboard ac-user-show --format json | \
-                python3 -c "import sys,json; print('\n'.join(json.load(sys.stdin)))")
-              while IFS= read -r user; do
-                [[ -z "$user" ]] && continue
-                found=false
-                for desired in "${DESIRED_USERS[@]}"; do
-                  [[ "$user" == "$desired" ]] && found=true && break
-                done
-                if [[ "$found" == "false" ]]; then
-                  echo "Removing stale user: $user"
-                  ceph dashboard ac-user-delete "$user"
-                fi
-              done <<< "$current_users"
 
               echo "SSO setup complete."
           env:

--- a/charts/rook-ceph-cluster/values.yaml
+++ b/charts/rook-ceph-cluster/values.yaml
@@ -65,49 +65,81 @@ oauth2-proxy:
           # https://github.com/oauth2-proxy/oauth2-proxy/issues/1714
           clientSecretFile: /dev/null
           oidcConfig:
-            issuerURL: https://auth.nicklasfrahm.dev
+            # URL of the OIDC issuer (e.g. https://dex.example.com).
+            issuerURL: ""
             groupsClaim: groups
           code_challenge_method: S256
+          # Restrict login to users in specific groups. Users outside these
+          # groups are denied at the proxy before reaching Ceph Dashboard.
+          # allowedGroups:
+          #   - org:team
       upstreamConfig:
         upstreams:
           - id: dashboard
-            uri: http://rook-ceph-mgr-dashboard:7000
+            uri: http://localhost:8080
             path: /
       injectRequestHeaders:
-        - name: X-Forwarded-User
+        - name: X-Access-Token
           values:
             - claimSource:
-                claim: user
-        - name: X-Forwarded-Email
-          values:
-            - claimSource:
-                claim: email
-        - name: Authorization
-          values:
-            - prefix: "Bearer "
-              tokenSource:
-                token: id_token
+                claim: access_token
   extraArgs:
     - --skip-provider-button=true
     - --reverse-proxy=true
+  extraContainers:
+    - name: jti-injector
+      image: openresty/openresty:1.27.1.2-alpine
+      ports:
+        - containerPort: 8080
+      resources:
+        limits:
+          memory: "64Mi"
+        requests:
+          cpu: "50m"
+          memory: "64Mi"
+      volumeMounts:
+        - name: jti-injector-config
+          mountPath: /usr/local/openresty/nginx/conf/nginx.conf
+          subPath: nginx.conf
+  extraVolumes:
+    - name: jti-injector-config
+      configMap:
+        # Must match {{ .Release.Name }}-jti-injector from the chart template.
+        name: rook-ceph-cluster-jti-injector
+  resources:
+    limits:
+      memory: "128Mi"
+    requests:
+      cpu: "50m"
+      memory: "128Mi"
+  # Public hostname for the Ceph Dashboard (required when enabled).
   httpRoute:
     enabled: true
     gateway:
       namespace: platform
       name: shared-http
     hostname: ""
+  # Upstream Ceph Dashboard service that the jti-injector sidecar proxies to.
+  dashboardUpstream: http://rook-ceph-mgr-dashboard:7000
   ssoSetup:
     enabled: true
     # Image must match the running Ceph cluster version.
     image: quay.io/ceph/ceph:v20.2.1
-    # GitHub usernames to pre-create as Ceph Dashboard administrators.
-    adminUsers: []
     # Names of the Rook-generated secret and configmap used to reach the MONs.
     monSecret: rook-ceph-mon
     monEndpointsConfigMap: rook-ceph-mon-endpoints
     # Set to true to opt in to Ceph telemetry (requires accepting the sharing license).
-    # Defaults to false to suppress HEALTH_WARN "Telemetry requires re-opt-in".
     telemetryOptIn: false
-    # JMESPath expression to extract roles from the JWT. If empty, role extraction is skipped.
-    # Example: contains(groups[*], 'org:team') && `["administrator"]` || `[]`
-    rolesPath: ""
+    # Maps OIDC groups to Ceph Dashboard roles. Groups are evaluated in order.
+    # Available roles: administrator, read-only, block-manager, rgw-manager,
+    #                  cluster-manager, pool-manager, cephfs-manager
+    # Example:
+    # groupRoles:
+    #   - group: org:admins
+    #     roles:
+    #       - administrator
+    #   - group: org:storage-team
+    #     roles:
+    #       - read-only
+    #       - pool-manager
+    groupRoles: []

--- a/deploy/clusters/prd-cph02/platform/rook-ceph-cluster.yml
+++ b/deploy/clusters/prd-cph02/platform/rook-ceph-cluster.yml
@@ -1,2 +1,2 @@
 chart: rook-ceph-cluster
-tag: 0.3.16
+tag: 0.3.17

--- a/deploy/services/rook-ceph-cluster/20-cluster-prd-cph02.yml
+++ b/deploy/services/rook-ceph-cluster/20-cluster-prd-cph02.yml
@@ -194,15 +194,13 @@ rook-ceph-cluster:
             name: shared-http
 
 oauth2-proxy:
-  enabled: false
+  enabled: true
   alphaConfig:
     configData:
       providers:
         - id: oidc
           provider: oidc
           clientID: ceph-dashboard
-          # oauth2-proxy requires a client secret even for public PKCE clients, /dev/null is the workaround:
-          # https://github.com/oauth2-proxy/oauth2-proxy/issues/1714
           clientSecretFile: /dev/null
           oidcConfig:
             issuerURL: https://auth.nicklasfrahm.dev
@@ -212,17 +210,16 @@ oauth2-proxy:
             - nicklasfrahm-dev:platform
   resources:
     limits:
+      cpu: "50m"
       memory: "128Mi"
     requests:
       cpu: "50m"
       memory: "128Mi"
   httpRoute:
-    gateway:
-      namespace: platform
-      name: shared-http
     hostname: ceph.cph02.nicklasfrahm.dev
   ssoSetup:
     telemetryOptIn: true
-    adminUsers:
-      - nicklasfrahm
-    rolesPath: "contains(groups[*], 'nicklasfrahm-dev:platform') && `[\"administrator\"]` || `[]`"
+    groupRoles:
+      - group: nicklasfrahm-dev:platform
+        roles:
+          - administrator


### PR DESCRIPTION
## Summary

- Re-integrates oauth2-proxy, jti-injector sidecar, HTTPRoute, and SSO setup job into `rook-ceph-cluster` under `oauth2-proxy.enabled`
- Removes the standalone `ceph-dashboard-proxy` chart
- Chart bumped to `0.3.18`

## Key improvements

- **jti-injector sidecar** (OpenResty/Lua) stamps a `jti` claim and rewrites `sub` to `preferred_username` — fixes Ceph Dashboard auth middleware compatibility with Dex tokens and gives human-readable usernames
- **`groupRoles` interface** replaces raw JMESPath `rolesPath` strings:
  ```yaml
  oauth2-proxy:
    ssoSetup:
      groupRoles:
        - group: org:admins
          roles: [administrator]
        - group: org:viewers
          roles: [read-only]
  ```
- **`dashboardUpstream`** controls the sidecar proxy target (defaults to `http://rook-ceph-mgr-dashboard:7000`)
- `allowedGroups` gates access at the proxy level before requests reach Ceph