### PR TITLE
fix(charts): prevent OIDC redirect loop on Ceph Dashboard token expiry

### DIFF
--- a/charts/dex/Chart.yaml
+++ b/charts/dex/Chart.yaml
@@ -3,7 +3,7 @@ type: application
 name: dex
 description: Deploy a Dex instance for single sign-on (SSO) and identity management.
 icon: https://dexidp.io/img/logos/dex-glyph-color.png
-version: 1.0.3
+version: 1.0.4
 appVersion: "0.24.0"
 dependencies:
   - name: dex

--- a/charts/dex/values.yaml
+++ b/charts/dex/values.yaml
@@ -43,6 +43,7 @@ dex:
       - id: ceph-dashboard
         name: "Ceph Dashboard"
         public: true
+        allowOfflineAccess: true
         redirectURIs:
           - "https://ceph.cph02.nicklasfrahm.dev/oauth2/callback"
   envVars:

--- a/deploy/clusters/prd-cph02/platform/dex.yml
+++ b/deploy/clusters/prd-cph02/platform/dex.yml
@@ -1,2 +1,2 @@
 chart: dex
-tag: 1.0.3
+tag: 1.0.4

--- a/deploy/services/rook-ceph-cluster/20-cluster-prd-cph02.yml
+++ b/deploy/services/rook-ceph-cluster/20-cluster-prd-cph02.yml
@@ -206,6 +206,7 @@ oauth2-proxy:
             issuerURL: https://auth.nicklasfrahm.dev
             groupsClaim: groups
           code_challenge_method: S256
+          scope: "openid email profile offline_access"
           allowedGroups:
             - nicklasfrahm-dev:platform
   resources:
@@ -215,6 +216,10 @@ oauth2-proxy:
     requests:
       cpu: "50m"
       memory: "128Mi"
+  extraArgs:
+    - --skip-provider-button=true
+    - --reverse-proxy=true
+    - --redirect-url=https://ceph.cph02.nicklasfrahm.dev/oauth2/callback
   httpRoute:
     hostname: ceph.cph02.nicklasfrahm.dev
   ssoSetup:


### PR DESCRIPTION
## Summary

- Adds `allowOfflineAccess: true` to the `ceph-dashboard` Dex client so Dex issues refresh tokens when requested
- Adds `scope: "openid email profile offline_access"` to the oauth2-proxy OIDC provider config so it requests a refresh token
- Bumps `charts/dex` to `1.0.4`

Without a refresh token, oauth2-proxy had to perform a full redirect to Dex whenever the access token expired. The old session cookie was not always fully cleared before the redirect — particularly when the previous session had been stored across multiple cookie chunks (`_oauth2_proxy_0` / `_oauth2_proxy_1`) but the new session fits in a single cookie (`_oauth2_proxy`). The browser would present the stale chunks on the next request, oauth2-proxy would read the expired session, and the loop would restart. Clearing the cookie manually broke the cycle because it removed all chunks.

With refresh tokens in place, oauth2-proxy silently refreshes the access token in-process — no redirect to Dex, no stale cookie interaction.