### PR TITLE
fix(charts): remove gateway-crds-helm to resolve duplicate CRD warnings

### DIFF
--- a/charts/envoy-gateway/Chart.yaml
+++ b/charts/envoy-gateway/Chart.yaml
@@ -3,18 +3,9 @@ type: application
 name: envoy-gateway
 description: Deploy Envoy Gateway as a Kubernetes-native API gateway.
 icon: https://www.envoyproxy.io/theme/images/envoy-logo.svg
-version: 0.1.0
+version: 0.1.1
 appVersion: "v1.8.0"
 dependencies:
-  - repository: oci://docker.io/envoyproxy
-    name: gateway-crds-helm
-    version: v1.8.0
-    condition: gateway-crds-helm.enabled
-    tags:
-      - networking
-      - gateway
-      - envoy
-      - crds
   - repository: oci://docker.io/envoyproxy
     name: gateway-helm
     version: v1.8.0

--- a/charts/envoy-gateway/values.yaml
+++ b/charts/envoy-gateway/values.yaml
@@ -1,12 +1,2 @@
-gateway-crds-helm:
-  enabled: true
-  crds:
-    gatewayAPI:
-      enabled: true
-      # Available options: standard, experimental
-      channel: experimental
-    envoyGateway:
-      enabled: true
-
 gateway-helm:
   enabled: true

--- a/deploy/clusters/prd-cph02/platform/envoy-gateway.yml
+++ b/deploy/clusters/prd-cph02/platform/envoy-gateway.yml
@@ -1,2 +1,2 @@
 chart: envoy-gateway
-tag: 0.1.0
+tag: 0.1.1


### PR DESCRIPTION
## Summary

- Removes `gateway-crds-helm` as a dependency from the `envoy-gateway` umbrella chart
- Deletes its vendored tarball and cleans up related values
- Bumps chart version to `0.1.1` and updates the cluster deploy tag

## Root cause

ArgoCD renders Helm charts via `helm template --include-crds`, which outputs CRDs from both the `templates/` and `crds/` directories. `gateway-crds-helm` installed CRDs via `templates/`, and `gateway-helm`'s bundled `crds` subchart installed the same set via `crds/` — both paths were included, causing every Gateway API and Envoy Gateway CRD to appear twice in the application resources.

## Fix

Remove `gateway-crds-helm` entirely. `gateway-helm` already bundles the same CRDs (experimental channel) in its `crds` subchart. ArgoCD will apply CRD updates on chart bumps since it always passes `--include-crds` during rendering, so there is no lifecycle regression.