### PR TITLE
feat(llm): add GitOps deployment config for cph02

### DIFF
--- a/deploy/clusters/prd-cph02/llm/llm.yml
+++ b/deploy/clusters/prd-cph02/llm/llm.yml
@@ -1,2 +1,2 @@
 chart: llm
-tag: 0.3.1
+tag: 0.3.7

--- a/deploy/clusters/prd-cph02/llm/llm.yml
+++ b/deploy/clusters/prd-cph02/llm/llm.yml
@@ -1,0 +1,2 @@
+chart: llm
+tag: 0.3.1

--- a/deploy/services/argocd-apps/20-cluster-prd-cph02.yml
+++ b/deploy/services/argocd-apps/20-cluster-prd-cph02.yml
@@ -5,3 +5,5 @@ tenants:
     enabled: true
   kommodity:
     enabled: true
+  llm:
+    enabled: true

--- a/deploy/services/llm/20-cluster-prd-cph02.yml
+++ b/deploy/services/llm/20-cluster-prd-cph02.yml
@@ -1,2 +1,2 @@
 model:
-  name: qwen35-opus46
+  name: qwen3-coder-30b

--- a/deploy/services/llm/20-cluster-prd-cph02.yml
+++ b/deploy/services/llm/20-cluster-prd-cph02.yml
@@ -1,0 +1,2 @@
+model:
+  name: qwen35-opus46


### PR DESCRIPTION
## Summary

- Adds `deploy/clusters/prd-cph02/llm/llm.yml` to register the `llm` Helm release with ArgoCD (chart `llm`, tag `0.3.1`)
- Adds `deploy/services/llm/20-cluster-prd-cph02.yml` with the live values (`model.name: qwen35-opus46`)
- Adds `llm` tenant to `deploy/services/argocd-apps/20-cluster-prd-cph02.yml` so ArgoCD manages the `llm` namespace

The `llm` namespace and Helm release already exist in `prd-cph02` (deployed manually 219 days ago). This PR brings them under GitOps control; ArgoCD will adopt the existing resources without re-creating them.

> **Note:** Chart `0.3.1` does not include the JWT `SecurityPolicy` template (added in `0.3.7`). A follow-up upgrade to `0.3.7` will require the `qwen35-opus46` model profile to be merged to `main` first (currently on `feat/llm-add-qwen35-27b-distilled`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)