### PR TITLE
feat(llm): bump vllm to v0.22.0 and deploy to cph02

### DIFF
--- a/charts/llm/Chart.yaml
+++ b/charts/llm/Chart.yaml
@@ -3,4 +3,4 @@ type: application
 name: llm
 description: A Helm chart for deploying a large language model via vLLM on KServe.
 icon: https://img.icons8.com/ios7/1200/electronic-brain.jpg
-version: 0.3.7
+version: 0.3.8

--- a/charts/llm/values.yaml
+++ b/charts/llm/values.yaml
@@ -1,6 +1,6 @@
 runtime:
   vllm:
-    version: "v0.20.0"
+    version: "v0.22.0"
 
 gpu:
   name: rtx3090

--- a/deploy/clusters/prd-cph02/llm/llm.yml
+++ b/deploy/clusters/prd-cph02/llm/llm.yml
@@ -1,2 +1,2 @@
 chart: llm
-tag: 0.3.7
+tag: 0.3.8


### PR DESCRIPTION
## Summary

- Bump vllm from `v0.20.0` to `v0.22.0` in chart default values
- Bump chart version `0.3.7` → `0.3.8`
- Update cph02 deployment tag to `0.3.8`