### PR TITLE
feat(llm): add per-credential ServiceAccount and token provisioning

### DIFF
--- a/charts/llm/Chart.yaml
+++ b/charts/llm/Chart.yaml
@@ -3,4 +3,4 @@ type: application
 name: llm
 description: A Helm chart for deploying a large language model via vLLM on KServe.
 icon: https://img.icons8.com/ios7/1200/electronic-brain.jpg
-version: 0.3.8
+version: 0.3.9

--- a/charts/llm/templates/serviceaccount.yaml
+++ b/charts/llm/templates/serviceaccount.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.auth.enabled }}
+{{- range $name, $enabled := .Values.auth.credentials }}
+{{- if $enabled }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $.Release.Name }}-{{ $name }}
+  namespace: {{ $.Release.Namespace }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $.Release.Name }}-{{ $name }}-token
+  namespace: {{ $.Release.Namespace }}
+  annotations:
+    kubernetes.io/service-account.name: {{ $.Release.Name }}-{{ $name }}
+type: kubernetes.io/service-account-token
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/llm/values.yaml
+++ b/charts/llm/values.yaml
@@ -125,3 +125,10 @@ auth:
     cph02:
       enabled: true
       jwksUri: "https://oidc.cph02.nicklasfrahm.dev/openid/v1/jwks"
+  credentials:
+    # Each enabled entry creates a ServiceAccount and a long-lived
+    # ServiceAccountToken Secret, both named "<release-name>-<key>".
+    # The resulting token is a Kubernetes service account JWT that can be
+    # used as a Bearer token via the cph02 OIDC issuer (see auth.providers.cph02).
+    # Ignored when auth.enabled is false.
+    example: false

--- a/deploy/clusters/prd-cph02/llm/llm.yml
+++ b/deploy/clusters/prd-cph02/llm/llm.yml
@@ -1,2 +1,2 @@
 chart: llm
-tag: 0.3.8
+tag: 0.3.9

--- a/deploy/services/llm/20-cluster-prd-cph02.yml
+++ b/deploy/services/llm/20-cluster-prd-cph02.yml
@@ -1,2 +1,6 @@
 model:
   name: qwen3-coder-30b
+
+auth:
+  credentials:
+    nicklasfrahm-t14gen3: true


### PR DESCRIPTION
## Summary
- Add an `auth.credentials` map (`string: bool`) to the `llm` chart — each enabled entry provisions a `ServiceAccount` and a long-lived `ServiceAccountToken` `Secret`, both named `<release-name>-<key>`.
- The resulting tokens are Kubernetes service-account JWTs that can be used as Bearer tokens against the LLM API via the cph02 OIDC issuer (validated by the existing `auth.providers.cph02` JWT provider).
- Credential provisioning is skipped entirely when `auth.enabled` is `false`.
- Bump chart version to 0.3.9 and the deploy tag in `deploy/clusters/prd-cph02/llm/llm.yml` to match.