### PR TITLE
feat(charts): bump oidc-discovery-proxy to 1.2.1

### DIFF
--- a/charts/oidc-discovery-proxy/Chart.yaml
+++ b/charts/oidc-discovery-proxy/Chart.yaml
@@ -3,9 +3,9 @@ type: application
 name: oidc-discovery-proxy
 description: Expose the Kubernetes OIDC discovery endpoints publicly for service account identity federation.
 icon: https://github.com/kommodity-io.png
-version: 1.0.1
-appVersion: "v1.2.0"
+version: 1.0.2
+appVersion: "v1.2.1"
 dependencies:
   - name: oidc-discovery-proxy
-    version: 1.1.0
+    version: 1.2.1
     repository: "oci://ghcr.io/kommodity-io/charts"

--- a/deploy/clusters/prd-cph02/platform/oidc-discovery-proxy.yml
+++ b/deploy/clusters/prd-cph02/platform/oidc-discovery-proxy.yml
@@ -1,2 +1,2 @@
 chart: oidc-discovery-proxy
-tag: 1.0.1
+tag: 1.0.2


### PR DESCRIPTION
## Summary
- Bump the `oidc-discovery-proxy` chart dependency from 1.1.0 to 1.2.1 (upstream `appVersion` v1.2.0 → v1.2.1)
- Bump the wrapper chart version from 1.0.1 to 1.0.2 and update `appVersion` to match
- Update the cph02 deployment config to track chart tag 1.0.2