### PR TITLE
feat(charts): bump oidc-discovery-proxy to 1.2.2 and deploy to cph02

### DIFF
--- a/charts/oidc-discovery-proxy/Chart.yaml
+++ b/charts/oidc-discovery-proxy/Chart.yaml
@@ -3,9 +3,9 @@ type: application
 name: oidc-discovery-proxy
 description: Expose the Kubernetes OIDC discovery endpoints publicly for service account identity federation.
 icon: https://github.com/kommodity-io.png
-version: 1.0.2
-appVersion: "v1.2.1"
+version: 1.0.3
+appVersion: "v1.2.2"
 dependencies:
   - name: oidc-discovery-proxy
-    version: 1.2.1
+    version: 1.2.2
     repository: "oci://ghcr.io/kommodity-io/charts"

--- a/deploy/clusters/prd-cph02/platform/oidc-discovery-proxy.yml
+++ b/deploy/clusters/prd-cph02/platform/oidc-discovery-proxy.yml
@@ -1,2 +1,2 @@
 chart: oidc-discovery-proxy
-tag: 1.0.2
+tag: 1.0.3


### PR DESCRIPTION
## Summary
- Bump oidc-discovery-proxy chart dependency and appVersion to upstream v1.2.2
- Bump deployed image tag for prd-cph02 from 1.0.2 to 1.0.3