### PR TITLE
feat(llm): add qwen36-27b profile and remove cph02 deployment

### DIFF
--- a/charts/llm/Chart.yaml
+++ b/charts/llm/Chart.yaml
@@ -3,4 +3,4 @@ type: application
 name: llm
 description: A Helm chart for deploying a large language model via vLLM on KServe.
 icon: https://img.icons8.com/ios7/1200/electronic-brain.jpg
-version: 0.3.10
+version: 0.3.11

--- a/charts/llm/values.yaml
+++ b/charts/llm/values.yaml
@@ -7,7 +7,7 @@ gpu:
   profile:
     rtx3090:
       maxNumSeqs: 1
-      gpuMemoryUtilization: 0.95
+      gpuMemoryUtilization: 0.99
       tensorParallelSize: 1
       resources:
         limits:
@@ -98,6 +98,15 @@ model:
         - "--max-model-len=65536"
         - "--quantization=compressed-tensors"
         - "--language-model-only"
+        - "--reasoning-parser=qwen3"
+        - "--tool-call-parser=qwen3_coder"
+    # Active: RTX 3090 (24GB), deployed on cph02
+    qwen36-27b:
+      modelId: "Intel/Qwen3.6-27B-int4-AutoRound"
+      servedModelName: "qwen36-27b"
+      args:
+        - "--max-model-len=65536"
+        - "--quantization=compressed-tensors"
         - "--reasoning-parser=qwen3"
         - "--tool-call-parser=qwen3_coder"
     # Untested: RTX 3090 (24GB)

--- a/deploy/clusters/prd-cph02/llm/llm.yml
+++ b/deploy/clusters/prd-cph02/llm/llm.yml
@@ -1,2 +1,0 @@
-chart: llm
-tag: 0.3.10

--- a/deploy/services/llm/20-cluster-prd-cph02.yml
+++ b/deploy/services/llm/20-cluster-prd-cph02.yml
@@ -1,6 +1,0 @@
-model:
-  name: qwen3-coder-30b
-
-auth:
-  credentials:
-    nicklasfrahm-t14gen3: true


### PR DESCRIPTION
## Summary

- Add a new `qwen36-27b` model profile (`Intel/Qwen3.6-27B-int4-AutoRound`, compressed-tensors quantization, 65536 context, qwen3 reasoning/tool-call parsers)
- Raise the `rtx3090` GPU profile's `gpuMemoryUtilization` from 0.95 to 0.99 to fix KV cache sizing failures on `qwen3-coder-30b`
- Bump `charts/llm` to 0.3.11
- Remove the LLM service from cph02 GitOps (`deploy/clusters/prd-cph02/llm/llm.yml`, `deploy/services/llm/20-cluster-prd-cph02.yml`); the chart remains available for future deployments